### PR TITLE
Only run npm install for javascript modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: npm ci
+          name: npm ci && npm run build
           # We run `npm run build` (`tsc`) as well because it is needed to
           # make storybook work. Our storybook setup is not (yet) able to
           # pick up .ts files - all code needs to be transpiled first.

--- a/.templates/javascript/default.mk
+++ b/.templates/javascript/default.mk
@@ -74,5 +74,9 @@ clean: clean-javascript
 .PHONY: clean
 
 clean-javascript:
-	rm -rf .deps .codegen .tested* node_modules coverage dist acceptance
+	rm -rf .deps .codegen .tested* coverage dist acceptance
 .PHONY: clean-javascript
+
+clobber: clean
+	rm -rf node_modules ../../node_modules
+.PHONY: clobber

--- a/.templates/javascript/default.mk
+++ b/.templates/javascript/default.mk
@@ -9,18 +9,21 @@ NPM_MODULE = $(shell cat package.json | jq .name --raw-output)
 default: .tested
 .PHONY: default
 
+../../node_modules ../../package-lock.json: package.json
+	cd ../.. && npm install
+
 .codegen:
 	touch $@
 
 .tested: .tested-npm .built
 
-.built: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.built: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	pushd ../.. && \
 	npm run build && \
 	popd && \
 	touch $@
 
-.tested-npm: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.tested-npm: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	npm run test
 	touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,8 @@ PACKAGES ?= messages \
 	demo-formatter \
 	json-to-messages
 
-default: .rsynced .typescript-built $(patsubst %,default-%,$(PACKAGES))
+default: .rsynced $(patsubst %,default-%,$(PACKAGES))
 .PHONY: default
-
-.typescript-built:
-	npm ci
-	npm run build
-.PHONY: .typescript-built
 
 default-%: %
 	cd $< && make default

--- a/compatibility-kit/javascript/default.mk
+++ b/compatibility-kit/javascript/default.mk
@@ -74,5 +74,9 @@ clean: clean-javascript
 .PHONY: clean
 
 clean-javascript:
-	rm -rf .deps .codegen .tested* node_modules coverage dist acceptance
+	rm -rf .deps .codegen .tested* coverage dist acceptance
 .PHONY: clean-javascript
+
+clobber: clean
+	rm -rf node_modules ../../node_modules
+.PHONY: clobber

--- a/compatibility-kit/javascript/default.mk
+++ b/compatibility-kit/javascript/default.mk
@@ -9,18 +9,21 @@ NPM_MODULE = $(shell cat package.json | jq .name --raw-output)
 default: .tested
 .PHONY: default
 
+../../node_modules ../../package-lock.json: package.json
+	cd ../.. && npm install
+
 .codegen:
 	touch $@
 
 .tested: .tested-npm .built
 
-.built: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.built: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	pushd ../.. && \
 	npm run build && \
 	popd && \
 	touch $@
 
-.tested-npm: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.tested-npm: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	npm run test
 	touch $@
 

--- a/create-meta/javascript/default.mk
+++ b/create-meta/javascript/default.mk
@@ -74,5 +74,9 @@ clean: clean-javascript
 .PHONY: clean
 
 clean-javascript:
-	rm -rf .deps .codegen .tested* node_modules coverage dist acceptance
+	rm -rf .deps .codegen .tested* coverage dist acceptance
 .PHONY: clean-javascript
+
+clobber: clean
+	rm -rf node_modules ../../node_modules
+.PHONY: clobber

--- a/create-meta/javascript/default.mk
+++ b/create-meta/javascript/default.mk
@@ -9,18 +9,21 @@ NPM_MODULE = $(shell cat package.json | jq .name --raw-output)
 default: .tested
 .PHONY: default
 
+../../node_modules ../../package-lock.json: package.json
+	cd ../.. && npm install
+
 .codegen:
 	touch $@
 
 .tested: .tested-npm .built
 
-.built: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.built: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	pushd ../.. && \
 	npm run build && \
 	popd && \
 	touch $@
 
-.tested-npm: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.tested-npm: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	npm run test
 	touch $@
 

--- a/cucumber-expressions/javascript/default.mk
+++ b/cucumber-expressions/javascript/default.mk
@@ -74,5 +74,9 @@ clean: clean-javascript
 .PHONY: clean
 
 clean-javascript:
-	rm -rf .deps .codegen .tested* node_modules coverage dist acceptance
+	rm -rf .deps .codegen .tested* coverage dist acceptance
 .PHONY: clean-javascript
+
+clobber: clean
+	rm -rf node_modules ../../node_modules
+.PHONY: clobber

--- a/cucumber-expressions/javascript/default.mk
+++ b/cucumber-expressions/javascript/default.mk
@@ -9,18 +9,21 @@ NPM_MODULE = $(shell cat package.json | jq .name --raw-output)
 default: .tested
 .PHONY: default
 
+../../node_modules ../../package-lock.json: package.json
+	cd ../.. && npm install
+
 .codegen:
 	touch $@
 
 .tested: .tested-npm .built
 
-.built: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.built: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	pushd ../.. && \
 	npm run build && \
 	popd && \
 	touch $@
 
-.tested-npm: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.tested-npm: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	npm run test
 	touch $@
 

--- a/fake-cucumber/javascript/default.mk
+++ b/fake-cucumber/javascript/default.mk
@@ -74,5 +74,9 @@ clean: clean-javascript
 .PHONY: clean
 
 clean-javascript:
-	rm -rf .deps .codegen .tested* node_modules coverage dist acceptance
+	rm -rf .deps .codegen .tested* coverage dist acceptance
 .PHONY: clean-javascript
+
+clobber: clean
+	rm -rf node_modules ../../node_modules
+.PHONY: clobber

--- a/fake-cucumber/javascript/default.mk
+++ b/fake-cucumber/javascript/default.mk
@@ -9,18 +9,21 @@ NPM_MODULE = $(shell cat package.json | jq .name --raw-output)
 default: .tested
 .PHONY: default
 
+../../node_modules ../../package-lock.json: package.json
+	cd ../.. && npm install
+
 .codegen:
 	touch $@
 
 .tested: .tested-npm .built
 
-.built: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.built: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	pushd ../.. && \
 	npm run build && \
 	popd && \
 	touch $@
 
-.tested-npm: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.tested-npm: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	npm run test
 	touch $@
 

--- a/gherkin-streams/javascript/default.mk
+++ b/gherkin-streams/javascript/default.mk
@@ -74,5 +74,9 @@ clean: clean-javascript
 .PHONY: clean
 
 clean-javascript:
-	rm -rf .deps .codegen .tested* node_modules coverage dist acceptance
+	rm -rf .deps .codegen .tested* coverage dist acceptance
 .PHONY: clean-javascript
+
+clobber: clean
+	rm -rf node_modules ../../node_modules
+.PHONY: clobber

--- a/gherkin-streams/javascript/default.mk
+++ b/gherkin-streams/javascript/default.mk
@@ -9,18 +9,21 @@ NPM_MODULE = $(shell cat package.json | jq .name --raw-output)
 default: .tested
 .PHONY: default
 
+../../node_modules ../../package-lock.json: package.json
+	cd ../.. && npm install
+
 .codegen:
 	touch $@
 
 .tested: .tested-npm .built
 
-.built: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.built: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	pushd ../.. && \
 	npm run build && \
 	popd && \
 	touch $@
 
-.tested-npm: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.tested-npm: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	npm run test
 	touch $@
 

--- a/gherkin-utils/javascript/default.mk
+++ b/gherkin-utils/javascript/default.mk
@@ -74,5 +74,9 @@ clean: clean-javascript
 .PHONY: clean
 
 clean-javascript:
-	rm -rf .deps .codegen .tested* node_modules coverage dist acceptance
+	rm -rf .deps .codegen .tested* coverage dist acceptance
 .PHONY: clean-javascript
+
+clobber: clean
+	rm -rf node_modules ../../node_modules
+.PHONY: clobber

--- a/gherkin-utils/javascript/default.mk
+++ b/gherkin-utils/javascript/default.mk
@@ -9,18 +9,21 @@ NPM_MODULE = $(shell cat package.json | jq .name --raw-output)
 default: .tested
 .PHONY: default
 
+../../node_modules ../../package-lock.json: package.json
+	cd ../.. && npm install
+
 .codegen:
 	touch $@
 
 .tested: .tested-npm .built
 
-.built: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.built: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	pushd ../.. && \
 	npm run build && \
 	popd && \
 	touch $@
 
-.tested-npm: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.tested-npm: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	npm run test
 	touch $@
 

--- a/gherkin/javascript/default.mk
+++ b/gherkin/javascript/default.mk
@@ -74,5 +74,9 @@ clean: clean-javascript
 .PHONY: clean
 
 clean-javascript:
-	rm -rf .deps .codegen .tested* node_modules coverage dist acceptance
+	rm -rf .deps .codegen .tested* coverage dist acceptance
 .PHONY: clean-javascript
+
+clobber: clean
+	rm -rf node_modules ../../node_modules
+.PHONY: clobber

--- a/gherkin/javascript/default.mk
+++ b/gherkin/javascript/default.mk
@@ -9,18 +9,21 @@ NPM_MODULE = $(shell cat package.json | jq .name --raw-output)
 default: .tested
 .PHONY: default
 
+../../node_modules ../../package-lock.json: package.json
+	cd ../.. && npm install
+
 .codegen:
 	touch $@
 
 .tested: .tested-npm .built
 
-.built: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.built: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	pushd ../.. && \
 	npm run build && \
 	popd && \
 	touch $@
 
-.tested-npm: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.tested-npm: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	npm run test
 	touch $@
 

--- a/html-formatter/javascript/default.mk
+++ b/html-formatter/javascript/default.mk
@@ -74,5 +74,9 @@ clean: clean-javascript
 .PHONY: clean
 
 clean-javascript:
-	rm -rf .deps .codegen .tested* node_modules coverage dist acceptance
+	rm -rf .deps .codegen .tested* coverage dist acceptance
 .PHONY: clean-javascript
+
+clobber: clean
+	rm -rf node_modules ../../node_modules
+.PHONY: clobber

--- a/html-formatter/javascript/default.mk
+++ b/html-formatter/javascript/default.mk
@@ -9,18 +9,21 @@ NPM_MODULE = $(shell cat package.json | jq .name --raw-output)
 default: .tested
 .PHONY: default
 
+../../node_modules ../../package-lock.json: package.json
+	cd ../.. && npm install
+
 .codegen:
 	touch $@
 
 .tested: .tested-npm .built
 
-.built: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.built: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	pushd ../.. && \
 	npm run build && \
 	popd && \
 	touch $@
 
-.tested-npm: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.tested-npm: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	npm run test
 	touch $@
 

--- a/json-formatter/javascript-testdata/default.mk
+++ b/json-formatter/javascript-testdata/default.mk
@@ -74,5 +74,9 @@ clean: clean-javascript
 .PHONY: clean
 
 clean-javascript:
-	rm -rf .deps .codegen .tested* node_modules coverage dist acceptance
+	rm -rf .deps .codegen .tested* coverage dist acceptance
 .PHONY: clean-javascript
+
+clobber: clean
+	rm -rf node_modules ../../node_modules
+.PHONY: clobber

--- a/json-formatter/javascript-testdata/default.mk
+++ b/json-formatter/javascript-testdata/default.mk
@@ -9,18 +9,21 @@ NPM_MODULE = $(shell cat package.json | jq .name --raw-output)
 default: .tested
 .PHONY: default
 
+../../node_modules ../../package-lock.json: package.json
+	cd ../.. && npm install
+
 .codegen:
 	touch $@
 
 .tested: .tested-npm .built
 
-.built: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.built: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	pushd ../.. && \
 	npm run build && \
 	popd && \
 	touch $@
 
-.tested-npm: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.tested-npm: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	npm run test
 	touch $@
 

--- a/json-to-messages/javascript-testdata/default.mk
+++ b/json-to-messages/javascript-testdata/default.mk
@@ -74,5 +74,9 @@ clean: clean-javascript
 .PHONY: clean
 
 clean-javascript:
-	rm -rf .deps .codegen .tested* node_modules coverage dist acceptance
+	rm -rf .deps .codegen .tested* coverage dist acceptance
 .PHONY: clean-javascript
+
+clobber: clean
+	rm -rf node_modules ../../node_modules
+.PHONY: clobber

--- a/json-to-messages/javascript-testdata/default.mk
+++ b/json-to-messages/javascript-testdata/default.mk
@@ -9,18 +9,21 @@ NPM_MODULE = $(shell cat package.json | jq .name --raw-output)
 default: .tested
 .PHONY: default
 
+../../node_modules ../../package-lock.json: package.json
+	cd ../.. && npm install
+
 .codegen:
 	touch $@
 
 .tested: .tested-npm .built
 
-.built: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.built: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	pushd ../.. && \
 	npm run build && \
 	popd && \
 	touch $@
 
-.tested-npm: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.tested-npm: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	npm run test
 	touch $@
 

--- a/json-to-messages/javascript/default.mk
+++ b/json-to-messages/javascript/default.mk
@@ -74,5 +74,9 @@ clean: clean-javascript
 .PHONY: clean
 
 clean-javascript:
-	rm -rf .deps .codegen .tested* node_modules coverage dist acceptance
+	rm -rf .deps .codegen .tested* coverage dist acceptance
 .PHONY: clean-javascript
+
+clobber: clean
+	rm -rf node_modules ../../node_modules
+.PHONY: clobber

--- a/json-to-messages/javascript/default.mk
+++ b/json-to-messages/javascript/default.mk
@@ -9,18 +9,21 @@ NPM_MODULE = $(shell cat package.json | jq .name --raw-output)
 default: .tested
 .PHONY: default
 
+../../node_modules ../../package-lock.json: package.json
+	cd ../.. && npm install
+
 .codegen:
 	touch $@
 
 .tested: .tested-npm .built
 
-.built: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.built: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	pushd ../.. && \
 	npm run build && \
 	popd && \
 	touch $@
 
-.tested-npm: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.tested-npm: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	npm run test
 	touch $@
 

--- a/message-streams/javascript/default.mk
+++ b/message-streams/javascript/default.mk
@@ -74,5 +74,9 @@ clean: clean-javascript
 .PHONY: clean
 
 clean-javascript:
-	rm -rf .deps .codegen .tested* node_modules coverage dist acceptance
+	rm -rf .deps .codegen .tested* coverage dist acceptance
 .PHONY: clean-javascript
+
+clobber: clean
+	rm -rf node_modules ../../node_modules
+.PHONY: clobber

--- a/message-streams/javascript/default.mk
+++ b/message-streams/javascript/default.mk
@@ -9,18 +9,21 @@ NPM_MODULE = $(shell cat package.json | jq .name --raw-output)
 default: .tested
 .PHONY: default
 
+../../node_modules ../../package-lock.json: package.json
+	cd ../.. && npm install
+
 .codegen:
 	touch $@
 
 .tested: .tested-npm .built
 
-.built: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.built: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	pushd ../.. && \
 	npm run build && \
 	popd && \
 	touch $@
 
-.tested-npm: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.tested-npm: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	npm run test
 	touch $@
 

--- a/messages/javascript/default.mk
+++ b/messages/javascript/default.mk
@@ -74,5 +74,9 @@ clean: clean-javascript
 .PHONY: clean
 
 clean-javascript:
-	rm -rf .deps .codegen .tested* node_modules coverage dist acceptance
+	rm -rf .deps .codegen .tested* coverage dist acceptance
 .PHONY: clean-javascript
+
+clobber: clean
+	rm -rf node_modules ../../node_modules
+.PHONY: clobber

--- a/messages/javascript/default.mk
+++ b/messages/javascript/default.mk
@@ -9,18 +9,21 @@ NPM_MODULE = $(shell cat package.json | jq .name --raw-output)
 default: .tested
 .PHONY: default
 
+../../node_modules ../../package-lock.json: package.json
+	cd ../.. && npm install
+
 .codegen:
 	touch $@
 
 .tested: .tested-npm .built
 
-.built: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.built: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	pushd ../.. && \
 	npm run build && \
 	popd && \
 	touch $@
 
-.tested-npm: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.tested-npm: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	npm run test
 	touch $@
 

--- a/query/javascript/default.mk
+++ b/query/javascript/default.mk
@@ -74,5 +74,9 @@ clean: clean-javascript
 .PHONY: clean
 
 clean-javascript:
-	rm -rf .deps .codegen .tested* node_modules coverage dist acceptance
+	rm -rf .deps .codegen .tested* coverage dist acceptance
 .PHONY: clean-javascript
+
+clobber: clean
+	rm -rf node_modules ../../node_modules
+.PHONY: clobber

--- a/query/javascript/default.mk
+++ b/query/javascript/default.mk
@@ -9,18 +9,21 @@ NPM_MODULE = $(shell cat package.json | jq .name --raw-output)
 default: .tested
 .PHONY: default
 
+../../node_modules ../../package-lock.json: package.json
+	cd ../.. && npm install
+
 .codegen:
 	touch $@
 
 .tested: .tested-npm .built
 
-.built: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.built: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	pushd ../.. && \
 	npm run build && \
 	popd && \
 	touch $@
 
-.tested-npm: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.tested-npm: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	npm run test
 	touch $@
 

--- a/react/javascript/default.mk
+++ b/react/javascript/default.mk
@@ -74,5 +74,9 @@ clean: clean-javascript
 .PHONY: clean
 
 clean-javascript:
-	rm -rf .deps .codegen .tested* node_modules coverage dist acceptance
+	rm -rf .deps .codegen .tested* coverage dist acceptance
 .PHONY: clean-javascript
+
+clobber: clean
+	rm -rf node_modules ../../node_modules
+.PHONY: clobber

--- a/react/javascript/default.mk
+++ b/react/javascript/default.mk
@@ -9,18 +9,21 @@ NPM_MODULE = $(shell cat package.json | jq .name --raw-output)
 default: .tested
 .PHONY: default
 
+../../node_modules ../../package-lock.json: package.json
+	cd ../.. && npm install
+
 .codegen:
 	touch $@
 
 .tested: .tested-npm .built
 
-.built: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.built: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	pushd ../.. && \
 	npm run build && \
 	popd && \
 	touch $@
 
-.tested-npm: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.tested-npm: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	npm run test
 	touch $@
 

--- a/tag-expressions/javascript/default.mk
+++ b/tag-expressions/javascript/default.mk
@@ -74,5 +74,9 @@ clean: clean-javascript
 .PHONY: clean
 
 clean-javascript:
-	rm -rf .deps .codegen .tested* node_modules coverage dist acceptance
+	rm -rf .deps .codegen .tested* coverage dist acceptance
 .PHONY: clean-javascript
+
+clobber: clean
+	rm -rf node_modules ../../node_modules
+.PHONY: clobber

--- a/tag-expressions/javascript/default.mk
+++ b/tag-expressions/javascript/default.mk
@@ -9,18 +9,21 @@ NPM_MODULE = $(shell cat package.json | jq .name --raw-output)
 default: .tested
 .PHONY: default
 
+../../node_modules ../../package-lock.json: package.json
+	cd ../.. && npm install
+
 .codegen:
 	touch $@
 
 .tested: .tested-npm .built
 
-.built: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.built: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	pushd ../.. && \
 	npm run build && \
 	popd && \
 	touch $@
 
-.tested-npm: $(TYPESCRIPT_SOURCE_FILES) .codegen
+.tested-npm: $(TYPESCRIPT_SOURCE_FILES) ../../node_modules ../../package-lock.json .codegen
 	npm run test
 	touch $@
 


### PR DESCRIPTION
This avoids running npm install when we specify e.g. `LANGUAGES=java make`