### PR TITLE
[build] Add Gherkin/Perl to the parallel build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -732,6 +732,19 @@ jobs:
             cd gherkin/dotnet
             make
 
+### Perl
+
+  gherkin-perl:
+    executor: docker-cucumber-build
+    steps:
+      - attach_workspace:
+          at: "~/cucumber"
+      - run:
+          name: gherkin/perl
+          command: |
+            cd gherkin/perl
+            make
+
 ### Python
 
   tag-expressions-python:
@@ -1026,6 +1039,12 @@ workflows:
             - prepare-parallel
 
       - gherkin-dotnet:
+          requires:
+            - prepare-parallel
+
+## Perl
+
+      - gherkin-perl:
           requires:
             - prepare-parallel
 


### PR DESCRIPTION
## Summary

Based on the example from Gherkin/dotNet, add Perl tests to the
parallel build.

