### PR TITLE
Create meta improvements

### DIFF
--- a/create-meta/CHANGELOG.md
+++ b/create-meta/CHANGELOG.md
@@ -9,13 +9,29 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Added support for [Jenkins](https://www.jenkins.io/) (via the [Git plugin](https://plugins.jenkins.io/git/))
+  ([#1253](https://github.com/cucumber/common/issues/1253)
+   [aslakhellesoy])
+* Added support for [Bitrise](https://www.bitrise.io/)
+  ([#1490](https://github.com/cucumber/common/issues/1490)
+   [aslakhellesoy])
+* Added support for [CodeShip](https://www.cloudbees.com/products/codeship)
+  ([#1490](https://github.com/cucumber/common/issues/1490)
+   [aslakhellesoy])
+
+
 ### Changed
+
+* Upgrade messages to 15.0.0
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+* Fixed detection of Semaphore build url.
+* Fixed detection of GoCD build url.
 
 ## [4.0.0] - 2021-03-29
 
@@ -81,7 +97,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * First release
 
 <!-- Releases -->
-[Unreleased]: https://github.com/cucumber/cucumber/compare/create-meta/v4.0.0...master
+[Unreleased]: https://github.com/cucumber/cucumber/compare/create-meta/v5.0.0...master
+[5.0.0]:      https://github.com/cucumber/cucumber/compare/create-meta/v4.0.0...create-meta/v5.0.0
 [4.0.0]:      https://github.com/cucumber/cucumber/compare/create-meta/v3.0.0...create-meta/v4.0.0
 [3.0.0]:      https://github.com/cucumber/cucumber/compare/create-meta/v2.0.4...create-meta/v3.0.0
 [2.0.4]:      https://github.com/cucumber/cucumber/compare/create-meta/v2.0.2...create-meta/v2.0.4

--- a/create-meta/CHANGELOG.md
+++ b/create-meta/CHANGELOG.md
@@ -11,14 +11,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Added support for [Jenkins](https://www.jenkins.io/) (via the [Git plugin](https://plugins.jenkins.io/git/))
   ([#1253](https://github.com/cucumber/common/issues/1253)
+   [#1553](https://github.com/cucumber/common/pull/1553)
    [aslakhellesoy])
 * Added support for [Bitrise](https://www.bitrise.io/)
   ([#1490](https://github.com/cucumber/common/issues/1490)
+   [#1553](https://github.com/cucumber/common/pull/1553)
+   [aslakhellesoy])
+* Added support for [CodeFresh](https://codefresh.io/)
+  ([#1553](https://github.com/cucumber/common/pull/1553)
    [aslakhellesoy])
 * Added support for [CodeShip](https://www.cloudbees.com/products/codeship)
-  ([#1490](https://github.com/cucumber/common/issues/1490)
+  ([#1553](https://github.com/cucumber/common/pull/1553)
    [aslakhellesoy])
-
 
 ### Changed
 
@@ -97,8 +101,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * First release
 
 <!-- Releases -->
-[Unreleased]: https://github.com/cucumber/cucumber/compare/create-meta/v5.0.0...master
-[5.0.0]:      https://github.com/cucumber/cucumber/compare/create-meta/v4.0.0...create-meta/v5.0.0
+[Unreleased]: https://github.com/cucumber/cucumber/compare/create-meta/v4.0.0...master
 [4.0.0]:      https://github.com/cucumber/cucumber/compare/create-meta/v3.0.0...create-meta/v4.0.0
 [3.0.0]:      https://github.com/cucumber/cucumber/compare/create-meta/v2.0.4...create-meta/v3.0.0
 [2.0.4]:      https://github.com/cucumber/cucumber/compare/create-meta/v2.0.2...create-meta/v2.0.4

--- a/create-meta/README.md
+++ b/create-meta/README.md
@@ -5,35 +5,50 @@ Utility function for creating system-specific `Meta` messages.
 ## CI
 
 The `ci` field of the `Meta` message contains values from environment variables
-defined by the most popular CI and build servers:
+defined by the following supported CI and build servers:
 
 * [Azure Pipelines](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?tabs=yaml&view=azure-devops#build-variables)
 * [Bamboo](https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html)
 * [Buddy](https://buddy.works/docs/pipelines/environment-variables#default-environment-variables)
+* [Bitrise](https://devcenter.bitrise.io/builds/available-environment-variables/)
 * [CircleCI](https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables)
 * [CodeFresh](https://codefresh.io/docs/docs/codefresh-yaml/variables/#system-provided-variables)
 * [CodeShip](https://documentation.codeship.com/basic/builds-and-configuration/set-environment-variables/)
 * [GitHub Actions](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables)
 * [GitLab](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html)
 * [GoCD](https://docs.gocd.org/current/faq/dev_use_current_revision_in_build.html)
+* [Jenkins](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables) and [Jenkins Git plugin](https://plugins.jenkins.io/git/#environment-variables)
+* [Semaphore](https://docs.semaphoreci.com/ci-cd-environment/environment-variables/)
 * [TeamCity](https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html)
   * Also see [REST API](https://www.jetbrains.com/help/teamcity/rest-api.html#)
 * [Travis CI](https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables)
 * [Wercker](https://devcenter.wercker.com/administration/environment-variables/available-env-vars/)
 
+### Adding support for new CI servers
+
+If you want to see support for a new CI server, please submit a pull request.
+
+Here are the steps:
+
+* Modify the top level `ciDict.json`, using environment variables to extract information.
+* Add an approval test in `testdata/YourCi.txt` and `testdata/YourCi.txt.json`.
+* Make copies of the modified files to all the implementations:
+
+    # From a bash shell
+    source ../scripts/functions.sh && rsync_files
+
+Then build and run the tests:
+
+    make clean && make
+
+If all tests pass, commit your code and send us a pull request. Bonus points if you
+also update `CHANGELOG.md` and `README.md`.
+
 ## CI definitions
 
-The `ciDict.json` file contains definitions of various CI servers. Each CI server
-provides a template for calculating a value from one or more environment variables.
+The `ciDict.json` file contains definitions of various CI servers. Each property of a CI
+server definition is an expression that evaluates a value from one or more environment variables.
 
-The template has a simple syntax that supports the following:
-
-* string interpolation with environment variables
-* defaults for variables that are not defined
-* extract branch or tag from refs - some CI servers do not provide these directly
-
-Examples:
-
-* `"revision": "${GITHUB_SHA}"` - substitutes with the value of the environment variable
-* `"remote": "${_GITHUB_BASEURL | https://github.com/}${GITHUB_REPOSITORY}.git"` - an example of defining a default value
-* `"branch": "${refbranch GITHUB_REF}"` - the `reftag` and `refbranch` prefixes extract tag or branch name from a git ref like `refs/heads/main`.
+The expression syntax for environment variables can use the form `${variable/pattern/replacement}`,
+similar to [bash parameter substitution](https://tldp.org/LDP/abs/html/parameter-substitution.html),
+but inspired from [sed's s command](https://www.gnu.org/software/sed/manual/html_node/The-_0022s_0022-Command.html) which provides support for capture group back-references in the replacement.

--- a/create-meta/ciDict.json
+++ b/create-meta/ciDict.json
@@ -4,8 +4,8 @@
     "git": {
       "remote": "${BUILD_REPOSITORY_URI}",
       "revision": "${BUILD_SOURCEVERSION}",
-      "branch": "${refbranch BUILD_SOURCEBRANCH}",
-      "tag": "${reftag BUILD_SOURCEBRANCH}"
+      "branch": "${BUILD_SOURCEBRANCH/refs\/heads\/(.*)/\\1}",
+      "tag": "${BUILD_SOURCEBRANCH/refs\/tags\/(.*)/\\1}"
     }
   },
   "Bamboo": {
@@ -26,6 +26,15 @@
       "tag": "${BUDDY_EXECUTION_TAG}"
     }
   },
+  "Bitrise": {
+    "url": "${BITRISE_BUILD_URL}",
+    "git": {
+      "remote": "${GIT_REPOSITORY_URL}",
+      "revision": "${BITRISE_GIT_COMMIT}",
+      "branch": "${BITRISE_GIT_BRANCH}",
+      "tag": "${BITRISE_GIT_TAG}"
+    }
+  },
   "CircleCI": {
     "url": "${CIRCLE_BUILD_URL}",
     "git": {
@@ -35,7 +44,7 @@
       "tag": "${CIRCLE_TAG}"
     }
   },
-  "CodeShip": {
+  "CodeFresh": {
     "url": "${CF_BUILD_URL}",
     "git": {
       "remote": "${CF_COMMIT_URL}",
@@ -44,13 +53,22 @@
       "tag": null
     }
   },
+  "CodeShip": {
+    "url": "${CI_BUILD_URL}",
+    "git": {
+      "remote": "${CI_PULL_REQUEST/(.*)\\/pull\\/\\d+/\\1.git}",
+      "revision": "${CI_COMMIT_ID}",
+      "branch": "${CI_BRANCH}",
+      "tag": null
+    }
+  },
   "GitHub Actions": {
     "url": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}",
     "git": {
       "remote": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git",
       "revision": "${GITHUB_SHA}",
-      "branch": "${refbranch GITHUB_REF}",
-      "tag": "${reftag GITHUB_REF}"
+      "branch": "${GITHUB_REF/refs\/heads\/(.*)/\\1}",
+      "tag": "${GITHUB_REF/refs\/tags\/(.*)/\\1}"
     }
   },
   "GitLab": {
@@ -63,16 +81,25 @@
     }
   },
   "GoCD": {
-    "url": "${GO_SERVER_URL}/???",
+    "url": "${GO_SERVER_URL}/pipelines/${GO_PIPELINE_NAME}/${GO_PIPELINE_COUNTER}/${GO_STAGE_NAME}/${GO_STAGE_COUNTER}",
     "git": {
-      "remote": null,
+      "remote": "${GO_SCM_*_PR_URL/(.*)\\/pull\\/\\d+/\\1.git}",
       "revision": "${GO_REVISION}",
-      "branch": null,
+      "branch": "${GO_SCM_*_PR_BRANCH/.*:(.*)/\\1}",
+      "tag": null
+    }
+  },
+  "Jenkins": {
+    "url": "${BUILD_URL}",
+    "git": {
+      "remote": "${GIT_URL}",
+      "revision": "${GIT_COMMIT}",
+      "branch": "${GIT_LOCAL_BRANCH}",
       "tag": null
     }
   },
   "Semaphore": {
-    "url": "${SEMAPHORE_ORGANIZATION_URL}/${}",
+    "url": "${SEMAPHORE_ORGANIZATION_URL}/jobs/${SEMAPHORE_JOB_ID}",
     "git": {
       "remote": "${SEMAPHORE_GIT_URL}",
       "revision": "${SEMAPHORE_GIT_SHA}",

--- a/create-meta/java/src/main/java/io/cucumber/createmeta/VariableExpression.java
+++ b/create-meta/java/src/main/java/io/cucumber/createmeta/VariableExpression.java
@@ -1,0 +1,53 @@
+package io.cucumber.createmeta;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class VariableExpression {
+    private static final Pattern variablePattern = Pattern.compile("\\$\\{(.*?)(?:(?<!\\\\)/(.*)/(.*))?}");
+
+    public static String evaluate(String expression, Map<String, String> env) {
+        if(expression == null) return null;
+        Matcher variableMatcher = variablePattern.matcher(expression);
+        StringBuffer sb = new StringBuffer();
+        while (variableMatcher.find()) {
+            String variable = variableMatcher.group(1);
+            String value = getValue(env, variable);
+            if(value == null) {
+                return null;
+            }
+            String pattern = variableMatcher.group(2);
+            if (pattern == null) {
+                variableMatcher.appendReplacement(sb, value);
+            } else {
+                Matcher matcher = Pattern.compile(pattern.replace("\\/", "/")).matcher(value);
+                if (!matcher.matches()) {
+                    return null;
+                }
+                String replacement = variableMatcher.group(3);
+                for (int i = 0; i < matcher.groupCount(); i++) {
+                    String group = matcher.group(i + 1);
+                    replacement = replacement.replace("\\" + (i + 1), group);
+                }
+                variableMatcher.appendReplacement(sb, replacement);
+            }
+        }
+        variableMatcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    private static String getValue(Map<String, String> env, String variable) {
+        if (variable.contains("*")) {
+            Pattern pattern = Pattern.compile(variable.replace("*", ".*"));
+            // GoCD env var with dynamic "material" name
+            // https://github.com/ashwanthkumar/gocd-build-github-pull-requests#github
+            for (Map.Entry<String, String> nameAndValue : env.entrySet()) {
+                if (pattern.matcher(nameAndValue.getKey()).matches()) {
+                    return nameAndValue.getValue();
+                }
+            }
+        }
+        return env.get(variable);
+    }
+}

--- a/create-meta/java/src/main/resources/io/cucumber/createmeta/ciDict.json
+++ b/create-meta/java/src/main/resources/io/cucumber/createmeta/ciDict.json
@@ -4,8 +4,8 @@
     "git": {
       "remote": "${BUILD_REPOSITORY_URI}",
       "revision": "${BUILD_SOURCEVERSION}",
-      "branch": "${refbranch BUILD_SOURCEBRANCH}",
-      "tag": "${reftag BUILD_SOURCEBRANCH}"
+      "branch": "${BUILD_SOURCEBRANCH/refs\/heads\/(.*)/\\1}",
+      "tag": "${BUILD_SOURCEBRANCH/refs\/tags\/(.*)/\\1}"
     }
   },
   "Bamboo": {
@@ -26,6 +26,15 @@
       "tag": "${BUDDY_EXECUTION_TAG}"
     }
   },
+  "Bitrise": {
+    "url": "${BITRISE_BUILD_URL}",
+    "git": {
+      "remote": "${GIT_REPOSITORY_URL}",
+      "revision": "${BITRISE_GIT_COMMIT}",
+      "branch": "${BITRISE_GIT_BRANCH}",
+      "tag": "${BITRISE_GIT_TAG}"
+    }
+  },
   "CircleCI": {
     "url": "${CIRCLE_BUILD_URL}",
     "git": {
@@ -35,7 +44,7 @@
       "tag": "${CIRCLE_TAG}"
     }
   },
-  "CodeShip": {
+  "CodeFresh": {
     "url": "${CF_BUILD_URL}",
     "git": {
       "remote": "${CF_COMMIT_URL}",
@@ -44,13 +53,22 @@
       "tag": null
     }
   },
+  "CodeShip": {
+    "url": "${CI_BUILD_URL}",
+    "git": {
+      "remote": "${CI_PULL_REQUEST/(.*)\\/pull\\/\\d+/\\1.git}",
+      "revision": "${CI_COMMIT_ID}",
+      "branch": "${CI_BRANCH}",
+      "tag": null
+    }
+  },
   "GitHub Actions": {
     "url": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}",
     "git": {
       "remote": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git",
       "revision": "${GITHUB_SHA}",
-      "branch": "${refbranch GITHUB_REF}",
-      "tag": "${reftag GITHUB_REF}"
+      "branch": "${GITHUB_REF/refs\/heads\/(.*)/\\1}",
+      "tag": "${GITHUB_REF/refs\/tags\/(.*)/\\1}"
     }
   },
   "GitLab": {
@@ -63,16 +81,25 @@
     }
   },
   "GoCD": {
-    "url": "${GO_SERVER_URL}/???",
+    "url": "${GO_SERVER_URL}/pipelines/${GO_PIPELINE_NAME}/${GO_PIPELINE_COUNTER}/${GO_STAGE_NAME}/${GO_STAGE_COUNTER}",
     "git": {
-      "remote": null,
+      "remote": "${GO_SCM_*_PR_URL/(.*)\\/pull\\/\\d+/\\1.git}",
       "revision": "${GO_REVISION}",
-      "branch": null,
+      "branch": "${GO_SCM_*_PR_BRANCH/.*:(.*)/\\1}",
+      "tag": null
+    }
+  },
+  "Jenkins": {
+    "url": "${BUILD_URL}",
+    "git": {
+      "remote": "${GIT_URL}",
+      "revision": "${GIT_COMMIT}",
+      "branch": "${GIT_LOCAL_BRANCH}",
       "tag": null
     }
   },
   "Semaphore": {
-    "url": "${SEMAPHORE_ORGANIZATION_URL}/${}",
+    "url": "${SEMAPHORE_ORGANIZATION_URL}/jobs/${SEMAPHORE_JOB_ID}",
     "git": {
       "remote": "${SEMAPHORE_GIT_URL}",
       "revision": "${SEMAPHORE_GIT_SHA}",

--- a/create-meta/java/src/test/java/io/cucumber/createmeta/CreateMetaTest.java
+++ b/create-meta/java/src/test/java/io/cucumber/createmeta/CreateMetaTest.java
@@ -3,10 +3,13 @@ package io.cucumber.createmeta;
 import io.cucumber.messages.types.Ci;
 import io.cucumber.messages.types.Git;
 import io.cucumber.messages.types.Meta;
+import io.cucumber.messages.JSON;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.HashMap;
 
+import static io.cucumber.createmeta.CreateMeta.createMeta;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -14,30 +17,30 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class CreateMetaTest {
     @Test
     void it_provides_the_correct_tool_name() {
-        Meta meta = CreateMeta.createMeta("cucumber-jvm", "3.2.1", new HashMap<>());
+        Meta meta = createMeta("cucumber-jvm", "3.2.1", new HashMap<>());
         assertEquals("cucumber-jvm", meta.getImplementation().getName());
     }
 
     @Test
     void it_provides_the_correct_tool_version() {
-        Meta meta = CreateMeta.createMeta("cucumber-jvm", "3.2.1", new HashMap<>());
+        Meta meta = createMeta("cucumber-jvm", "3.2.1", new HashMap<>());
         assertEquals("3.2.1", meta.getImplementation().getVersion());
     }
 
     @Test
     void it_provides_the_correct_protocol_version() {
-        Meta meta = CreateMeta.createMeta("cucumber-jvm", "3.2.1", new HashMap<>());
+        Meta meta = createMeta("cucumber-jvm", "3.2.1", new HashMap<>());
         assertThat(meta.getProtocolVersion(), matchesPattern("\\d+\\.\\d+\\.\\d+(-SNAPSHOT)?"));
     }
 
     @Test
     void it_provides_the_correct_jvm_version_and_name() {
-        Meta meta = CreateMeta.createMeta("cucumber-jvm", "3.2.1", new HashMap<>());
+        Meta meta = createMeta("cucumber-jvm", "3.2.1", new HashMap<>());
         assertThat(meta.getRuntime().getName(), matchesPattern("(OpenJDK).*"));
     }
 
     @Test
-    void it_detects_github_actions() {
+    void it_detects_github_actions() throws IOException {
         HashMap<String, String> env = new HashMap<String, String>() {{
             put("GITHUB_SERVER_URL", "https://github.company.com");
             put("GITHUB_REPOSITORY", "cucumber/cucumber-ruby");
@@ -45,7 +48,8 @@ class CreateMetaTest {
             put("GITHUB_SHA", "the-revision");
             put("GITHUB_REF", "refs/tags/the-tag");
         }};
-        Meta meta = CreateMeta.createMeta("cucumber-jvm", "3.2.1", env);
+        Meta meta = createMeta("cucumber-jvm", "3.2.1", env);
+        System.out.println("JSON.toJSON(meta.getCi()) = " + JSON.toJSON(meta.getCi()));
 
         assertEquals(new Ci(
                         "GitHub Actions",
@@ -61,23 +65,32 @@ class CreateMetaTest {
     }
 
     @Test
-    void can_handle_CIs_with_null_in_ciDict() {
-        // choose gocd as example, which has null everywhere except for url and revision
+    void it_detects_go_cd() throws IOException {
+        // https://github.com/gocd/gocd/blob/3e948218bfb163c5c3d2bf5140cb4a12f110769e/server/src/main/webapp/WEB-INF/rails/config/routes.rb#L55
         HashMap<String, String> env = new HashMap<String, String>() {{
-            put("GO_SERVER_URL", "https://<cihost>/buildurl");
+            put("GO_SERVER_URL", "https://mygocd.com");
+            put("GO_PIPELINE_NAME", "my-pipeline");
+            put("GO_PIPELINE_COUNTER", "1234");
+            put("GO_STAGE_NAME", "my-stage");
+            put("GO_STAGE_COUNTER", "456");
             put("GO_REVISION", "the-revision");
+            // https://github.com/ashwanthkumar/gocd-build-github-pull-requests
+            put("GO_SCM_MY_MATERIAL_PR_BRANCH", "ashwankthkumar:feature-1");
+            put("GO_SCM_MY_MATERIAL_PR_URL", "https://github.com/owner/repo/pull/1669");
         }};
-        Meta meta = CreateMeta.createMeta("cucumber-jvm", "3.2.1", env);
+        Meta meta = createMeta("cucumber-jvm", "3.2.1", env);
+
         assertEquals(new Ci(
                         "GoCD",
-                        "https://<cihost>/buildurl/???",
+                        "https://mygocd.com/pipelines/my-pipeline/1234/my-stage/456",
                         new Git(
-                                null,
+                                "https://github.com/owner/repo.git",
                                 "the-revision",
-                                null,
+                                "feature-1",
                                 null
                         )
                 ),
-                meta.getCi());
+                meta.getCi(),
+                "The Git JSON was:\n" + JSON.toJSON(meta.getCi()));
     }
 }

--- a/create-meta/java/src/test/java/io/cucumber/createmeta/VariableExpressionTest.java
+++ b/create-meta/java/src/test/java/io/cucumber/createmeta/VariableExpressionTest.java
@@ -1,0 +1,55 @@
+package io.cucumber.createmeta;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static io.cucumber.createmeta.VariableExpression.evaluate;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class VariableExpressionTest {
+    @Test
+    public void it_returns_null_when_a_variable_is_undefined() {
+        String expression = "hello-${SOME_VAR}";
+        String result = evaluate(expression, new HashMap<>());
+        assertNull(result);
+    }
+
+    @Test
+    public void it_gets_a_value_without_replacement() {
+        String expression = "${SOME_VAR}";
+        String result = evaluate(expression, new HashMap<String, String>() {{
+            put("SOME_VAR", "some_value");
+        }});
+        assertEquals("some_value", result);
+    }
+
+    @Test
+    public void it_captures_a_group() {
+        String expression = "${SOME_REF/refs\\/heads\\/(.*)/\\1}";
+        String result = evaluate(expression, new HashMap<String, String>() {{
+            put("SOME_REF", "refs/heads/main");
+        }});
+        assertEquals("main", result);
+    }
+
+    @Test
+    public void it_works_with_star_wildcard_in_var() {
+        String expression = "${GO_SCM_*_PR_BRANCH/.*:(.*)/\\1}";
+        String result = evaluate(expression, new HashMap<String, String>() {{
+            put("GO_SCM_MY_MATERIAL_PR_BRANCH", "ashwankthkumar:feature-1");
+        }});
+        assertEquals("feature-1", result);
+    }
+
+    @Test
+    public void it_evaluates_a_complex_expression() {
+        String expression = "hello-${VAR1}-${VAR2/(.*) (.*)/\\2-\\1}-world";
+        String result = evaluate(expression, new HashMap<String, String>() {{
+            put("VAR1", "amazing");
+            put("VAR2", "gorgeous beautiful");
+        }});
+        assertEquals("hello-amazing-beautiful-gorgeous-world", result);
+    }
+}

--- a/create-meta/javascript/package.json
+++ b/create-meta/javascript/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@cucumber/create-meta",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Produce the meta message for Cucumber JavaScript",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
     "test": "mocha",
     "prepublishOnly": "tsc --build tsconfig.build.json",
-    "print-meta": "ts-node --require tsconfig-paths/register ./src/printMeta.ts"
+    "print-meta": "ts-node --require source-map-support/register --require tsconfig-paths/register ./src/printMeta.ts"
   },
   "repository": {
     "type": "git",

--- a/create-meta/javascript/package.json
+++ b/create-meta/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cucumber/create-meta",
-  "version": "5.0.0",
+  "version": "4.0.0",
   "description": "Produce the meta message for Cucumber JavaScript",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/create-meta/javascript/src/ciDict.json
+++ b/create-meta/javascript/src/ciDict.json
@@ -4,8 +4,8 @@
     "git": {
       "remote": "${BUILD_REPOSITORY_URI}",
       "revision": "${BUILD_SOURCEVERSION}",
-      "branch": "${refbranch BUILD_SOURCEBRANCH}",
-      "tag": "${reftag BUILD_SOURCEBRANCH}"
+      "branch": "${BUILD_SOURCEBRANCH/refs\/heads\/(.*)/\\1}",
+      "tag": "${BUILD_SOURCEBRANCH/refs\/tags\/(.*)/\\1}"
     }
   },
   "Bamboo": {
@@ -26,6 +26,15 @@
       "tag": "${BUDDY_EXECUTION_TAG}"
     }
   },
+  "Bitrise": {
+    "url": "${BITRISE_BUILD_URL}",
+    "git": {
+      "remote": "${GIT_REPOSITORY_URL}",
+      "revision": "${BITRISE_GIT_COMMIT}",
+      "branch": "${BITRISE_GIT_BRANCH}",
+      "tag": "${BITRISE_GIT_TAG}"
+    }
+  },
   "CircleCI": {
     "url": "${CIRCLE_BUILD_URL}",
     "git": {
@@ -35,7 +44,7 @@
       "tag": "${CIRCLE_TAG}"
     }
   },
-  "CodeShip": {
+  "CodeFresh": {
     "url": "${CF_BUILD_URL}",
     "git": {
       "remote": "${CF_COMMIT_URL}",
@@ -44,13 +53,22 @@
       "tag": null
     }
   },
+  "CodeShip": {
+    "url": "${CI_BUILD_URL}",
+    "git": {
+      "remote": "${CI_PULL_REQUEST/(.*)\\/pull\\/\\d+/\\1.git}",
+      "revision": "${CI_COMMIT_ID}",
+      "branch": "${CI_BRANCH}",
+      "tag": null
+    }
+  },
   "GitHub Actions": {
     "url": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}",
     "git": {
       "remote": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git",
       "revision": "${GITHUB_SHA}",
-      "branch": "${refbranch GITHUB_REF}",
-      "tag": "${reftag GITHUB_REF}"
+      "branch": "${GITHUB_REF/refs\/heads\/(.*)/\\1}",
+      "tag": "${GITHUB_REF/refs\/tags\/(.*)/\\1}"
     }
   },
   "GitLab": {
@@ -63,16 +81,25 @@
     }
   },
   "GoCD": {
-    "url": "${GO_SERVER_URL}/???",
+    "url": "${GO_SERVER_URL}/pipelines/${GO_PIPELINE_NAME}/${GO_PIPELINE_COUNTER}/${GO_STAGE_NAME}/${GO_STAGE_COUNTER}",
     "git": {
-      "remote": null,
+      "remote": "${GO_SCM_*_PR_URL/(.*)\\/pull\\/\\d+/\\1.git}",
       "revision": "${GO_REVISION}",
-      "branch": null,
+      "branch": "${GO_SCM_*_PR_BRANCH/.*:(.*)/\\1}",
+      "tag": null
+    }
+  },
+  "Jenkins": {
+    "url": "${BUILD_URL}",
+    "git": {
+      "remote": "${GIT_URL}",
+      "revision": "${GIT_COMMIT}",
+      "branch": "${GIT_LOCAL_BRANCH}",
       "tag": null
     }
   },
   "Semaphore": {
-    "url": "${SEMAPHORE_ORGANIZATION_URL}/${}",
+    "url": "${SEMAPHORE_ORGANIZATION_URL}/jobs/${SEMAPHORE_JOB_ID}",
     "git": {
       "remote": "${SEMAPHORE_GIT_URL}",
       "revision": "${SEMAPHORE_GIT_SHA}",

--- a/create-meta/javascript/src/createMeta.ts
+++ b/create-meta/javascript/src/createMeta.ts
@@ -2,9 +2,10 @@ import os from 'os'
 import { parse as parseUrl, format as formatUrl } from 'url'
 import * as messages from '@cucumber/messages'
 import defaultCiDict from './ciDict.json'
+import evaluateVariableExpression from "./evaluateVariableExpression";
 
-export type CiDict = { [name: string]: CiSystem }
-export type EnvDict = { [name: string]: string | undefined }
+export type CiDict = Record<string,CiSystem>
+export type Env = Record<string,string|undefined>
 
 export interface CiSystem {
   url: string
@@ -19,7 +20,7 @@ export interface CiSystem {
 export default function createMeta(
   toolName: string,
   toolVersion: string,
-  envDict: EnvDict,
+  envDict: Env,
   ciDict?: CiDict
 ): messages.Meta {
   if (ciDict === undefined) {
@@ -46,7 +47,7 @@ export default function createMeta(
   }
 }
 
-export function detectCI(ciDict: CiDict, envDict: EnvDict): messages.Ci | undefined {
+export function detectCI(ciDict: CiDict, envDict: Env): messages.Ci | undefined {
   const detected: messages.Ci[] = []
   for (const [ciName, ciSystem] of Object.entries(ciDict)) {
     const ci = createCi(ciName, ciSystem, envDict)
@@ -56,6 +57,10 @@ export function detectCI(ciDict: CiDict, envDict: EnvDict): messages.Ci | undefi
   }
   if (detected.length !== 1) {
     return undefined
+  }
+  if (detected.length > 1) {
+    console.error(`@cucumber/create-meta WARNING: Detected more than one CI: ${JSON.stringify(detected, null, 2)}`)
+    console.error('Using the first one.')
   }
   return detected[0]
 }
@@ -68,66 +73,24 @@ export function removeUserInfoFromUrl(value: string): string {
   return formatUrl(url)
 }
 
-function createCi(ciName: string, ciSystem: CiSystem, envDict: EnvDict): messages.Ci | undefined {
-  const url = evaluate(ciSystem.url, envDict)
+function createCi(ciName: string, ciSystem: CiSystem, envDict: Env): messages.Ci | undefined {
+  const url = evaluateVariableExpression(ciSystem.url, envDict)
   if (url === undefined) {
     // The url is what consumers will use as the primary key for a build
     // If this cannot be determined, we return nothing.
     return undefined
   }
 
+  let branch = evaluateVariableExpression(ciSystem.git.branch, envDict);
   return {
     url,
     name: ciName,
     git: {
-      remote: removeUserInfoFromUrl(evaluate(ciSystem.git.remote, envDict)),
-      revision: evaluate(ciSystem.git.revision, envDict),
-      branch: evaluate(ciSystem.git.branch, envDict),
-      tag: evaluate(ciSystem.git.tag, envDict),
+      remote: removeUserInfoFromUrl(evaluateVariableExpression(ciSystem.git.remote, envDict)),
+      revision: evaluateVariableExpression(ciSystem.git.revision, envDict),
+      branch: branch,
+      tag: evaluateVariableExpression(ciSystem.git.tag, envDict),
     },
   }
 }
 
-/**
- * Evaluates a simple template
- *
- * @param template - the template from the ciDict.json file
- * @param envDict - variables
- * @return the evaluated template, or undefined if a variable was undefined
- */
-function evaluate(template: string, envDict: EnvDict): string | undefined {
-  if (template === undefined) {
-    return undefined
-  }
-  try {
-    return template.replace(
-      /\${((refbranch|reftag)\s+)?([^\s}]+)(\s+\|\s+([^}]+))?}/g,
-      (substring: string, ...args: any[]): string => {
-        const func = args[1]
-        const variable = args[2]
-        const defaultValue = args[4]
-        const value = envDict[variable] || defaultValue
-        if (value === undefined) {
-          throw new Error(`Undefined variable: ${variable}`)
-        }
-        switch (func) {
-          case 'refbranch':
-            return group1(value, /^refs\/heads\/(.*)/)
-          case 'reftag':
-            return group1(value, /^refs\/tags\/(.*)/)
-          default:
-            return value
-        }
-      }
-    )
-  } catch (err) {
-    // There was an undefined variable
-    return undefined
-  }
-}
-
-function group1(value: string, regexp: RegExp): string {
-  const match = value.match(regexp)
-  if (match === null) throw new Error('No match')
-  return match[1]
-}

--- a/create-meta/javascript/src/evaluateVariableExpression.ts
+++ b/create-meta/javascript/src/evaluateVariableExpression.ts
@@ -1,0 +1,51 @@
+import {Env} from "./createMeta";
+
+export default function evaluateVariableExpression(expression: string | undefined, env: Env): string | undefined {
+  if (expression === undefined) {
+    return undefined
+  }
+  try {
+    const re = new RegExp("\\${(.*?)(?:(?<!\\\\)/(.*)/(.*))?}", 'g')
+    return expression.replace(
+      re,
+      (substring, ...args): string => {
+        const variable = args[0]
+        const value = getValue(env, variable)
+        if (value === undefined) {
+          throw new Error(`Undefined variable: ${variable}`)
+        }
+        const pattern = args[1]
+        if(!pattern) {
+          return value
+        }
+        const regExp = new RegExp(pattern.replace('\/', '/'));
+        const match = regExp.exec(value)
+        if(!match) {
+          throw new Error(`No match for: ${variable}`)
+        }
+        let replacement = args[2]
+        let ref = 1
+        for (const group of match.slice(1)) {
+          replacement = replacement.replace(`\\${ref++}`, group)
+        }
+        return replacement
+      }
+    )
+  } catch (err) {
+    // There was an undefined variable
+    return undefined
+  }
+}
+
+function getValue(env: Env, variable: string) {
+  if(variable.includes('*')) {
+    const regexp = new RegExp(variable.replace('*', '.*'))
+    for (const [name, value] of Object.entries(env)) {
+      if(regexp.exec(name)) {
+        return value
+      }
+    }
+  }
+  return env[variable];
+}
+

--- a/create-meta/javascript/test/evaluateVariableExpressionTest.ts
+++ b/create-meta/javascript/test/evaluateVariableExpressionTest.ts
@@ -1,0 +1,35 @@
+import createMeta from '../src/createMeta'
+import assert from 'assert'
+import evaluateVariableExpression from "../src/evaluateVariableExpression";
+
+describe('createMeta', () => {
+  it('returns undefined when a variable is undefined', () => {
+    const expression = "hello-${SOME_VAR}";
+    const result = evaluateVariableExpression(expression, {});
+    assert.strictEqual(result, undefined)
+  })
+
+  it('gets a value without replacement', () => {
+    const expression = "${SOME_VAR}";
+    const result = evaluateVariableExpression(expression, {SOME_VAR: 'some_value'});
+    assert.strictEqual(result, 'some_value')
+  })
+
+  it('captures a group', () => {
+    const expression = "${SOME_REF/refs\\/heads\\/(.*)/\\1}";
+    const result = evaluateVariableExpression(expression, {SOME_REF: 'refs/heads/main'});
+    assert.strictEqual(result, 'main')
+  })
+
+  it('works with star wildcard in var', () => {
+    const expression = "${GO_SCM_*_PR_BRANCH/.*:(.*)/\\1}";
+    const result = evaluateVariableExpression(expression, {GO_SCM_MY_MATERIAL_PR_BRANCH: 'ashwankthkumar:feature-1'});
+    assert.strictEqual(result, 'feature-1')
+  })
+
+  it('evaluates a complex expression', () => {
+    const expression = "hello-${VAR1}-${VAR2/(.*) (.*)/\\2-\\1}-world";
+    const result = evaluateVariableExpression(expression, {VAR1: "amazing", VAR2: "gorgeous beautiful"});
+    assert.strictEqual(result, 'hello-amazing-beautiful-gorgeous-world')
+  })
+})

--- a/create-meta/ruby/lib/cucumber/ciDict.json
+++ b/create-meta/ruby/lib/cucumber/ciDict.json
@@ -4,8 +4,8 @@
     "git": {
       "remote": "${BUILD_REPOSITORY_URI}",
       "revision": "${BUILD_SOURCEVERSION}",
-      "branch": "${refbranch BUILD_SOURCEBRANCH}",
-      "tag": "${reftag BUILD_SOURCEBRANCH}"
+      "branch": "${BUILD_SOURCEBRANCH/refs\/heads\/(.*)/\\1}",
+      "tag": "${BUILD_SOURCEBRANCH/refs\/tags\/(.*)/\\1}"
     }
   },
   "Bamboo": {
@@ -26,6 +26,15 @@
       "tag": "${BUDDY_EXECUTION_TAG}"
     }
   },
+  "Bitrise": {
+    "url": "${BITRISE_BUILD_URL}",
+    "git": {
+      "remote": "${GIT_REPOSITORY_URL}",
+      "revision": "${BITRISE_GIT_COMMIT}",
+      "branch": "${BITRISE_GIT_BRANCH}",
+      "tag": "${BITRISE_GIT_TAG}"
+    }
+  },
   "CircleCI": {
     "url": "${CIRCLE_BUILD_URL}",
     "git": {
@@ -35,7 +44,7 @@
       "tag": "${CIRCLE_TAG}"
     }
   },
-  "CodeShip": {
+  "CodeFresh": {
     "url": "${CF_BUILD_URL}",
     "git": {
       "remote": "${CF_COMMIT_URL}",
@@ -44,13 +53,22 @@
       "tag": null
     }
   },
+  "CodeShip": {
+    "url": "${CI_BUILD_URL}",
+    "git": {
+      "remote": "${CI_PULL_REQUEST/(.*)\\/pull\\/\\d+/\\1.git}",
+      "revision": "${CI_COMMIT_ID}",
+      "branch": "${CI_BRANCH}",
+      "tag": null
+    }
+  },
   "GitHub Actions": {
     "url": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}",
     "git": {
       "remote": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git",
       "revision": "${GITHUB_SHA}",
-      "branch": "${refbranch GITHUB_REF}",
-      "tag": "${reftag GITHUB_REF}"
+      "branch": "${GITHUB_REF/refs\/heads\/(.*)/\\1}",
+      "tag": "${GITHUB_REF/refs\/tags\/(.*)/\\1}"
     }
   },
   "GitLab": {
@@ -63,16 +81,25 @@
     }
   },
   "GoCD": {
-    "url": "${GO_SERVER_URL}/???",
+    "url": "${GO_SERVER_URL}/pipelines/${GO_PIPELINE_NAME}/${GO_PIPELINE_COUNTER}/${GO_STAGE_NAME}/${GO_STAGE_COUNTER}",
     "git": {
-      "remote": null,
+      "remote": "${GO_SCM_*_PR_URL/(.*)\\/pull\\/\\d+/\\1.git}",
       "revision": "${GO_REVISION}",
-      "branch": null,
+      "branch": "${GO_SCM_*_PR_BRANCH/.*:(.*)/\\1}",
+      "tag": null
+    }
+  },
+  "Jenkins": {
+    "url": "${BUILD_URL}",
+    "git": {
+      "remote": "${GIT_URL}",
+      "revision": "${GIT_COMMIT}",
+      "branch": "${GIT_LOCAL_BRANCH}",
       "tag": null
     }
   },
   "Semaphore": {
-    "url": "${SEMAPHORE_ORGANIZATION_URL}/${}",
+    "url": "${SEMAPHORE_ORGANIZATION_URL}/jobs/${SEMAPHORE_JOB_ID}",
     "git": {
       "remote": "${SEMAPHORE_GIT_URL}",
       "revision": "${SEMAPHORE_GIT_SHA}",

--- a/create-meta/ruby/lib/cucumber/create_meta.rb
+++ b/create-meta/ruby/lib/cucumber/create_meta.rb
@@ -1,10 +1,12 @@
 require 'uri'
-require 'cucumber/messages'
 require 'sys/uname'
 require 'json'
+require 'cucumber/messages'
+require 'cucumber/create_meta/variable_expression'
 
 module Cucumber
   module CreateMeta
+    extend Cucumber::CreateMeta::VariableExpression
     CI_DICT = JSON.parse(IO.read(File.join(File.dirname(__FILE__), "ciDict.json")))
 
     def create_meta(tool_name, tool_version, env = ENV)
@@ -53,34 +55,6 @@ module Cucumber
       }
     end
 
-    def evaluate(template, env)
-      return nil if template.nil?
-      begin
-        template.gsub(/\${((refbranch|reftag)\s+)?([^\s}]+)(\s+\|\s+([^}]+))?}/) do
-          func = $2
-          variable = $3
-          default_value = $5 == "" ? nil : $5
-          value = env[variable] || default_value
-
-          if func == 'refbranch'
-            value = group1(value, /^refs\/heads\/(.*)/)
-          elsif func == 'reftag'
-            value = group1(value, /^refs\/tags\/(.*)/)
-          end
-          raise "Undefined variable: #{variable}" if value.nil?
-          value
-        end
-      rescue
-        nil
-      end
-    end
-
-    def group1(value, regexp)
-      m = value.match(regexp)
-      raise "No match" if m.nil?
-      m[1]
-    end
-
     def remove_userinfo_from_url(value)
       return nil if value.nil?
       begin
@@ -92,6 +66,6 @@ module Cucumber
       end
     end
 
-    module_function :create_meta, :detect_ci, :create_ci, :group1, :evaluate, :remove_userinfo_from_url
+    module_function :create_meta, :detect_ci, :create_ci, :remove_userinfo_from_url
   end
 end

--- a/create-meta/ruby/lib/cucumber/create_meta/variable_expression.rb
+++ b/create-meta/ruby/lib/cucumber/create_meta/variable_expression.rb
@@ -1,0 +1,41 @@
+module Cucumber
+  module CreateMeta
+    module VariableExpression
+      def evaluate(expression, env)
+        return nil if expression.nil?
+        begin
+          expression.gsub(/\${(.*?)(?:(?<!\\)\/(.*)\/(.*))?}/) do
+            variable = $1
+            pattern = $2
+            replacement = $3
+
+            value = get_value(variable, env)
+            raise "Undefined variable #{variable}" if value.nil?
+            if pattern.nil?
+              value
+            else
+              regexp = Regexp.new(pattern.gsub('\/', '/'))
+              match = value.match(regexp)
+              raise "No match for variable #{variable}" if match.nil?
+              match[1..-1].each_with_index do |group, i|
+                replacement = replacement.gsub("\\#{i+1}", group)
+              end
+              replacement
+            end
+          end
+        rescue
+          nil
+        end
+      end
+
+      def get_value(variable, env)
+        if variable.index('*')
+          env.each do |name, value|
+            return value if Regexp.new(variable.gsub('*', '.*')) =~ name
+          end
+        end
+        env[variable]
+      end
+    end
+  end
+end

--- a/create-meta/ruby/spec/cucumber/create_meta_spec.rb
+++ b/create-meta/ruby/spec/cucumber/create_meta_spec.rb
@@ -1,6 +1,6 @@
 require 'cucumber/create_meta'
 
-describe 'createMeta' do
+describe 'create_meta' do
   it 'generates a Meta message with platform information' do
     meta = Cucumber::CreateMeta.create_meta('cucumba-ruby', 'X.Y.Z')
 

--- a/create-meta/ruby/spec/cucumber/evaluate_variable_expression_spec.rb
+++ b/create-meta/ruby/spec/cucumber/evaluate_variable_expression_spec.rb
@@ -1,0 +1,38 @@
+require 'cucumber/create_meta'
+
+describe 'Cucumber::CreateMeta::VariableExpression.evaluate' do
+  include Cucumber::CreateMeta::VariableExpression
+
+  it 'returns nil when a variable is undefined' do
+    expression = "hello-${SOME_VAR}";
+    result = evaluate(expression, {});
+    expect(result).to eq(nil)
+  end
+
+  it 'gets a value without replacement' do
+    expression = "${SOME_VAR}";
+    result = evaluate(expression, {'SOME_VAR' => 'some_value'});
+    expect(result).to eq('some_value')
+  end
+
+  it 'captures a group' do
+    expression = "${SOME_REF/refs\/heads\/(.*)/\\1}";
+    result = evaluate(expression, {'SOME_REF' => 'refs/heads/main'});
+    expect(result).to eq('main')
+  end
+
+  it 'works with star wildcard in var' do
+    expression = "${GO_SCM_*_PR_BRANCH/.*:(.*)/\\1}";
+    result = evaluate(expression, {'GO_SCM_MY_MATERIAL_PR_BRANCH' => 'ashwankthkumar:feature-1'});
+    expect(result).to eq('feature-1')
+  end
+
+  it 'evaluates a complex expression' do
+    expression = "hello-${VAR1}-${VAR2/(.*) (.*)/\\2-\\1}-world";
+    result = evaluate(expression, {
+      'VAR1' => 'amazing',
+      'VAR2' => 'gorgeous beautiful'
+    })
+    expect(result).to eq('hello-amazing-beautiful-gorgeous-world')
+  end
+end

--- a/create-meta/testdata/Bitrise.txt
+++ b/create-meta/testdata/Bitrise.txt
@@ -1,0 +1,4 @@
+BITRISE_BUILD_URL=https://cihost.com/path/to/the/build
+GIT_REPOSITORY_URL=https://scmhost.com/path/to/the/project
+BITRISE_GIT_BRANCH=main
+BITRISE_GIT_COMMIT=decafbad

--- a/create-meta/testdata/Bitrise.txt.json
+++ b/create-meta/testdata/Bitrise.txt.json
@@ -1,9 +1,9 @@
 {
   "git": {
     "branch": "main",
-    "remote": "https://github.com/owner/repo.git",
+    "remote": "https://scmhost.com/path/to/the/project",
     "revision": "decafbad"
   },
-  "name": "CodeShip",
+  "name": "Bitrise",
   "url": "https://cihost.com/path/to/the/build"
 }

--- a/create-meta/testdata/CodeShip.txt
+++ b/create-meta/testdata/CodeShip.txt
@@ -1,4 +1,4 @@
-CF_BUILD_URL=https://cihost.com/path/to/the/build
-CF_COMMIT_URL=https://scmhost.com/path/to/the/project
-CF_BRANCH=main
-CF_REVISION=decafbad
+CI_BUILD_URL=https://cihost.com/path/to/the/build
+CI_PULL_REQUEST=https://github.com/owner/repo/pull/42
+CI_BRANCH=main
+CI_COMMIT_ID=decafbad

--- a/create-meta/testdata/GoCD.txt
+++ b/create-meta/testdata/GoCD.txt
@@ -1,2 +1,8 @@
-GO_SERVER_URL=https://cihost.com/path/to/the/build
+GO_SERVER_URL=https://cihost.com
+GO_PIPELINE_NAME=my-pipeline-name
+GO_PIPELINE_COUNTER=1234
+GO_STAGE_NAME=my-stage-name
+GO_STAGE_COUNTER=456
 GO_REVISION=decafbad
+GO_SCM_MY_MATERIAL_PR_BRANCH=aslakhellesoy:bug-fix-42
+GO_SCM_MY_MATERIAL_PR_URL=https://github.com/owner/repo/pull/1669

--- a/create-meta/testdata/GoCD.txt.json
+++ b/create-meta/testdata/GoCD.txt.json
@@ -1,7 +1,9 @@
 {
   "git": {
+    "branch": "bug-fix-42",
+    "remote": "https://github.com/owner/repo.git",
     "revision": "decafbad"
   },
   "name": "GoCD",
-  "url": "https://cihost.com/path/to/the/build/???"
+  "url": "https://cihost.com/pipelines/my-pipeline-name/1234/my-stage-name/456"
 }

--- a/create-meta/testdata/Jenkins.txt
+++ b/create-meta/testdata/Jenkins.txt
@@ -1,0 +1,4 @@
+BUILD_URL=https://cihost.com/path/to/the/build
+GIT_URL=https://scmhost.com/path/to/the/project
+GIT_LOCAL_BRANCH=main
+GIT_COMMIT=decafbad

--- a/create-meta/testdata/Jenkins.txt.json
+++ b/create-meta/testdata/Jenkins.txt.json
@@ -1,9 +1,9 @@
 {
   "git": {
     "branch": "main",
-    "remote": "https://github.com/owner/repo.git",
+    "remote": "https://scmhost.com/path/to/the/project",
     "revision": "decafbad"
   },
-  "name": "CodeShip",
+  "name": "Jenkins",
   "url": "https://cihost.com/path/to/the/build"
 }


### PR DESCRIPTION
This fixes several bugs in create-meta where we weren't properly generating the right values.

This PR also introduces a new expression language - `${variable/pattern/replacement}` - similar to [bash parameter substitution](https://tldp.org/LDP/abs/html/parameter-substitution.html), but inspired from [sed's s command](https://www.gnu.org/software/sed/manual/html_node/The-_0022s_0022-Command.html) which provides support for capture group back-references in the replacement.

This will make it easier to add support for other CI servers in the future, without any code changes.