### PR TITLE
gherkin/ruby: Fix tagging of rules

### DIFF
--- a/gherkin/CHANGELOG.md
+++ b/gherkin/CHANGELOG.md
@@ -19,7 +19,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ### Fixed
 * [Ruby] Rules weren't inheriting the relevant tags during the Gherkin Query stage (Where it caches the NodeID)
-  ([#????](https://github.com/cucumber/cucumber/pull/????) [luke-hill])
+  ([#1593](https://github.com/cucumber/cucumber/pull/1593) [luke-hill])
 
 ## [19.0.3] - 2021-05-24
 

--- a/gherkin/CHANGELOG.md
+++ b/gherkin/CHANGELOG.md
@@ -18,6 +18,8 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 ### Removed
 
 ### Fixed
+* [Ruby] Rules weren't inheriting the relevant tags during the Gherkin Query stage (Where it caches the NodeID)
+  ([#????](https://github.com/cucumber/cucumber/pull/????) [luke-hill])
 
 ## [19.0.3] - 2021-05-24
 
@@ -1086,6 +1088,7 @@ to Gherkin 2.
 [KniveX]:            https://github.com/KniveX
 [l3pp4rd]:           https://github.com/l3pp4rd
 [LiohAu]:            https://github.com/LiohAu
+[luke-hill]:         https://github.com/luke-hill
 [mattwynne]:         https://github.com/mattwynne
 [mauriciotogneri]:   https://github.com/mauriciotogneri
 [maximeg]:           https://github.com/maximeg

--- a/gherkin/ruby/lib/gherkin/query.rb
+++ b/gherkin/ruby/lib/gherkin/query.rb
@@ -27,6 +27,9 @@ module Gherkin
     end
 
     def update_rule(rule)
+      return if rule.nil?
+      store_nodes_location(rule[:tags])
+
       rule[:children].each do |child|
         update_background(child[:background]) if child[:background]
         update_scenario(child[:scenario]) if child[:scenario]


### PR DESCRIPTION
## Summary
Fix tagging of Rules

## Details

During the Gherkin Query cache step where it finds all data and relates them to specific AST Node IDs, it wasn't storing tag data. This was likely because similar to features, it needs to look "up" and not down through descendents

## Motivation and Context

Fix Ruby

## How Has This Been Tested?

CI
Altered tests in cucumber-ruby
Discussion during general meeting about executing portions of the regular CCK against all flavours of cucumber

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG accordingly.

