### PR TITLE
Rebuild go packages if go.mod changes

### DIFF
--- a/.templates/go/default.mk
+++ b/.templates/go/default.mk
@@ -51,7 +51,7 @@ endif
 
 dist: $(EXES)
 
-dist/$(EXE_BASE_NAME)-%: .deps $(GO_SOURCE_FILES)
+dist/$(EXE_BASE_NAME)-%: .deps $(GO_SOURCE_FILES) go.mod
 	mkdir -p dist
 	echo "EXES=$(EXES)"
 	echo "Building $@"

--- a/cucumber-expressions/go/default.mk
+++ b/cucumber-expressions/go/default.mk
@@ -51,7 +51,7 @@ endif
 
 dist: $(EXES)
 
-dist/$(EXE_BASE_NAME)-%: .deps $(GO_SOURCE_FILES)
+dist/$(EXE_BASE_NAME)-%: .deps $(GO_SOURCE_FILES) go.mod
 	mkdir -p dist
 	echo "EXES=$(EXES)"
 	echo "Building $@"

--- a/demo-formatter/go/default.mk
+++ b/demo-formatter/go/default.mk
@@ -51,7 +51,7 @@ endif
 
 dist: $(EXES)
 
-dist/$(EXE_BASE_NAME)-%: .deps $(GO_SOURCE_FILES)
+dist/$(EXE_BASE_NAME)-%: .deps $(GO_SOURCE_FILES) go.mod
 	mkdir -p dist
 	echo "EXES=$(EXES)"
 	echo "Building $@"

--- a/gherkin/go/default.mk
+++ b/gherkin/go/default.mk
@@ -51,7 +51,7 @@ endif
 
 dist: $(EXES)
 
-dist/$(EXE_BASE_NAME)-%: .deps $(GO_SOURCE_FILES)
+dist/$(EXE_BASE_NAME)-%: .deps $(GO_SOURCE_FILES) go.mod
 	mkdir -p dist
 	echo "EXES=$(EXES)"
 	echo "Building $@"

--- a/json-formatter/go/default.mk
+++ b/json-formatter/go/default.mk
@@ -51,7 +51,7 @@ endif
 
 dist: $(EXES)
 
-dist/$(EXE_BASE_NAME)-%: .deps $(GO_SOURCE_FILES)
+dist/$(EXE_BASE_NAME)-%: .deps $(GO_SOURCE_FILES) go.mod
 	mkdir -p dist
 	echo "EXES=$(EXES)"
 	echo "Building $@"

--- a/messages/go/default.mk
+++ b/messages/go/default.mk
@@ -51,7 +51,7 @@ endif
 
 dist: $(EXES)
 
-dist/$(EXE_BASE_NAME)-%: .deps $(GO_SOURCE_FILES)
+dist/$(EXE_BASE_NAME)-%: .deps $(GO_SOURCE_FILES) go.mod
 	mkdir -p dist
 	echo "EXES=$(EXES)"
 	echo "Building $@"

--- a/tag-expressions/go/default.mk
+++ b/tag-expressions/go/default.mk
@@ -51,7 +51,7 @@ endif
 
 dist: $(EXES)
 
-dist/$(EXE_BASE_NAME)-%: .deps $(GO_SOURCE_FILES)
+dist/$(EXE_BASE_NAME)-%: .deps $(GO_SOURCE_FILES) go.mod
 	mkdir -p dist
 	echo "EXES=$(EXES)"
 	echo "Building $@"


### PR DESCRIPTION
## Summary

Change default Makefile for Go packages to rebuild if the `go.mod` file changes

## Motivation and Context

I'm working on #1550 and fiddling about with the `go.mod` files. It seems the Makefile needs this dependency expressed.

## Types of changes

- [x] Technical debt
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

