### PR TITLE
handle null hook in HookStep component

### DIFF
--- a/react/javascript/src/components/gherkin/HookStep.tsx
+++ b/react/javascript/src/components/gherkin/HookStep.tsx
@@ -20,11 +20,13 @@ const HookStep: React.FunctionComponent<IProps> = ({ step }) => {
   const attachments = cucumberQuery.getTestStepsAttachments([step.id])
 
   if (stepResult.status === 'FAILED') {
-    const location = hook.sourceReference.location
-      ? hook.sourceReference.uri + ':' + hook.sourceReference.location.line
-      : hook.sourceReference.javaMethod
-      ? hook.sourceReference.javaMethod.className + '.' + hook.sourceReference.javaMethod.methodName
-      : 'Unknown location'
+    let location = 'Unknown location'
+    if (hook && hook.sourceReference.location) {
+      location = `${hook.sourceReference.uri}:${hook.sourceReference.location.line}`
+    } else if (hook && hook.sourceReference.javaMethod) {
+      location = `${hook.sourceReference.javaMethod.className}.${hook.sourceReference.javaMethod.methodName}`
+    }
+
     return (
       <StepItem status={stepResult.status}>
         <Title header="h3" id={step.id}>

--- a/react/javascript/test/components/gherkin/HookStepTest.tsx
+++ b/react/javascript/test/components/gherkin/HookStepTest.tsx
@@ -1,0 +1,63 @@
+import assert from 'assert'
+import ReactDOM from 'react-dom'
+import React from 'react'
+import * as messages from '@cucumber/messages'
+import { Query as CucumberQuery } from '@cucumber/query'
+import { JSDOM } from 'jsdom'
+
+import UriContext from '../../../src/UriContext'
+import GherkinQueryContext from '../../../src/GherkinQueryContext'
+import { Query as GherkinQuery } from '@cucumber/gherkin-utils'
+import CucumberQueryContext from '../../../src/CucumberQueryContext'
+import HookStep from '../../../src/components/gherkin/HookStep'
+
+describe('<HookStep>', () => {
+  it('doesnt explode when we cant find a hook message for a failed hook', () => {
+    const dom = new JSDOM('<html lang="en"><body><div id="content"></div></body></html>')
+    // @ts-ignore
+    global.window = dom.window
+    // global.navigator = dom.window.navigator
+    const document = dom.window.document
+
+    const step: messages.TestStep = {
+      id: '123',
+      hookId: '456',
+    }
+
+    class StubCucumberQuery extends CucumberQuery {
+      getTestStepResults(): messages.TestStepResult[] {
+        return [
+          {
+            status: messages.TestStepResultStatus.FAILED,
+            message: 'whoops',
+            duration: {
+              seconds: 1,
+              nanos: 0,
+            },
+            willBeRetried: false,
+          },
+        ]
+      }
+
+      getHook(): messages.Hook {
+        return null
+      }
+    }
+
+    const app = (
+      <GherkinQueryContext.Provider value={new GherkinQuery()}>
+        <UriContext.Provider value={'some.feature'}>
+          <CucumberQueryContext.Provider value={new StubCucumberQuery()}>
+            <HookStep step={step} />
+          </CucumberQueryContext.Provider>
+        </UriContext.Provider>
+      </GherkinQueryContext.Provider>
+    )
+    ReactDOM.render(app, document.getElementById('content'))
+
+    assert.strictEqual(
+      document.getElementById('content').textContent.includes('Hook failed: Unknown location'),
+      true
+    )
+  })
+})


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Prevent an error when rendering the failure of a hook where that hook has no `hook` message from which to find its location.

## Motivation and Context

Fixes #1304.

cucumber-jvm filters out `hook` messages due to volume, so we need to handle that gracefully when rendering.

## How Has This Been Tested?

- Unit test added
- Modified acceptance test data locally to test in storybook

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.

