### PR TITLE
react: alter left offset for anchor in step line

### DIFF
--- a/react/CHANGELOG.md
+++ b/react/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* Stop the anchor link for the step from overlapping the status icon
+
 ## [16.2.0] - 2021-06-02
 
 ### Added

--- a/react/javascript/src/components/gherkin/Anchor.module.scss
+++ b/react/javascript/src/components/gherkin/Anchor.module.scss
@@ -12,7 +12,7 @@
   transition: all 0.35s ease-in-out;
   position: absolute;
   font-size: 0.75rem;
-  left: -1rem;
+  left: var(--cucumber-anchor-offset, -1.25em);
 
   .wrapper:hover & {
     opacity: 1;

--- a/react/javascript/src/components/gherkin/StepItem.module.scss
+++ b/react/javascript/src/components/gherkin/StepItem.module.scss
@@ -2,6 +2,7 @@ $statusWidth: 1.5em;
 
 .container {
   display: flex;
+  --cucumber-anchor-offset: -3.25em;
 }
 
 .status {


### PR DESCRIPTION
## Summary

Stop the anchor link for the step from overlapping the status icon.

(Must have missed this in the big styling PR last month.)

## Screenshots (if appropriate):

Before:

![image](https://user-images.githubusercontent.com/3192745/121772865-20ae4680-cb70-11eb-9150-16a1ace5ebc9.png)

After:

![image](https://user-images.githubusercontent.com/3192745/121772880-315ebc80-cb70-11eb-84d2-abdeed3bba2d.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.

