### PR TITLE
build: use latest cucumber/build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
   # the build nodes (faster builds).
   docker-cucumber-build:
     docker:
-      - image: cucumber/cucumber-build:0.5.0
+      - image: cucumber/cucumber-build:0.5.2
     working_directory: ~/cucumber
     environment:
       # nvm, node and npm are installed locally rather globally.


### PR DESCRIPTION
To get changes from https://github.com/cucumber/build/pull/34

Should unblock https://github.com/cucumber/common/pull/1610