### PR TITLE
Point go module paths to monorepo

### DIFF
--- a/cucumber-expressions/CHANGELOG.md
+++ b/cucumber-expressions/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* [Go] Move module paths to point to monorepo
+  ([#1550](https://github.com/cucumber/common/issues/1550))
+
 ### Deprecated
 
 ### Removed

--- a/cucumber-expressions/go/go.mod
+++ b/cucumber-expressions/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/cucumber/cucumber-expressions-go/v12
+module github.com/cucumber/common/cucumber-expressions/go/v12
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/demo-formatter/go/cmd/main.go
+++ b/demo-formatter/go/cmd/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	formatter "github.com/cucumber/demo-formatter-go"
+	formatter "github.com/cucumber/common/demo-formatter/go"
 	"os"
 )
 

--- a/demo-formatter/go/go.mod
+++ b/demo-formatter/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/cucumber/demo-formatter-go
+module github.com/cucumber/common/demo-formatter/go
 
 require (
 	github.com/cucumber/messages-go/v16 v16.0.1

--- a/gherkin/CHANGELOG.md
+++ b/gherkin/CHANGELOG.md
@@ -13,6 +13,9 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ### Changed
 
+* [Go] Move module paths to point to monorepo
+  ([#1550](https://github.com/cucumber/common/issues/1550))
+
 ### Deprecated
 
 ### Removed

--- a/gherkin/go/cmd/main.go
+++ b/gherkin/go/cmd/main.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/cucumber/gherkin-go/v19"
+	"github.com/cucumber/common/gherkin/go/v19"
 	"github.com/cucumber/messages-go/v16"
 	"os"
 )

--- a/gherkin/go/gherkin-generate-tokens/gherkin-generate-tokens.go
+++ b/gherkin/go/gherkin-generate-tokens/gherkin-generate-tokens.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/cucumber/gherkin-go/v19"
+	"github.com/cucumber/common/gherkin/go/v19"
 	"io"
 	"os"
 	"strings"

--- a/gherkin/go/go.mod
+++ b/gherkin/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/cucumber/gherkin-go/v19
+module github.com/cucumber/common/gherkin/go/v19
 
 require (
 	github.com/cucumber/messages-go/v16 v16.0.1

--- a/json-formatter/CHANGELOG.md
+++ b/json-formatter/CHANGELOG.md
@@ -13,6 +13,9 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ### Changed
 
+* [Go] Move module paths to point to monorepo
+  ([#1550](https://github.com/cucumber/common/issues/1550))
+
 ### Deprecated
 
 ### Removed

--- a/json-formatter/go/cmd/main.go
+++ b/json-formatter/go/cmd/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	jsonFormatter "github.com/cucumber/json-formatter-go/v18"
+	jsonFormatter "github.com/cucumber/common/json-formatter/go/v18"
 	"log"
 	"os"
 )

--- a/json-formatter/go/go.mod
+++ b/json-formatter/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/cucumber/json-formatter-go/v18
+module github.com/cucumber/common/json-formatter/go/v18
 
 replace github.com/cucumber/messages-go/v16 => ../../messages/go
 

--- a/messages/CHANGELOG.md
+++ b/messages/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* [Go] Move module paths to point to monorepo
+  ([#1550](https://github.com/cucumber/common/issues/1550))
+
 ### Deprecated
 
 ### Removed

--- a/messages/go/go.mod
+++ b/messages/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/cucumber/messages-go/v16
+module github.com/cucumber/common/messages/go/v16
 
 require (
 	github.com/gofrs/uuid v4.0.0+incompatible

--- a/tag-expressions/CHANGELOG.md
+++ b/tag-expressions/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* [Go] Move module paths to point to monorepo
+  ([#1550](https://github.com/cucumber/common/issues/1550))
+
 ### Deprecated
 
 ### Removed

--- a/tag-expressions/go/go.mod
+++ b/tag-expressions/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/cucumber/cucumber/tag-expressions-go/v3
+module github.com/cucumber/common/cucumber/tag-expressions/go/v3
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect


### PR DESCRIPTION
Ref #1550

This PR changes each of the go module's paths to point to inside the monorepo instead of to the mirror subrepo.

This is to prepare the ground for #1608 to update the references that point _to_ these modules, once this PR has been merged to main, since Go default to look for the `go.mod` files on the repo's default branch.
