### PR TITLE
Use native RegExp Match indices

### DIFF
--- a/cucumber-expressions/CHANGELOG.md
+++ b/cucumber-expressions/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* Use native RegExp Match indices (currently relying on a polyfill)
+  ([#1652](https://github.com/cucumber/common/pull/1652)
+   [aslakhellesoy])
+
 ## [12.1.1] - 2021-04-06
 
 ### Fixed

--- a/cucumber-expressions/javascript/package.json
+++ b/cucumber-expressions/javascript/package.json
@@ -34,6 +34,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
+    "regexp-match-indices": "1.0.2"
   },
   "directories": {
     "test": "test"

--- a/cucumber-expressions/javascript/package.json
+++ b/cucumber-expressions/javascript/package.json
@@ -34,7 +34,6 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "becke-ch--regex--s0-0-v1--base--pl--lib": "1.4.0"
   },
   "directories": {
     "test": "test"

--- a/cucumber-expressions/javascript/src/Group.ts
+++ b/cucumber-expressions/javascript/src/Group.ts
@@ -1,12 +1,12 @@
 export default class Group {
   constructor(
     public readonly value: string | undefined,
-    public readonly start: number,
-    public readonly end: number,
+    public readonly start: number | undefined,
+    public readonly end: number | undefined,
     public readonly children: readonly Group[]
   ) {}
 
-  get values(): string[] {
+  get values(): readonly string[] {
     return (this.children.length === 0 ? [this] : this.children).map((g) => g.value)
   }
 }

--- a/cucumber-expressions/javascript/src/Group.ts
+++ b/cucumber-expressions/javascript/src/Group.ts
@@ -6,7 +6,7 @@ export default class Group {
     public readonly children: readonly Group[]
   ) {}
 
-  get values(): readonly string[] {
+  get values(): string[] {
     return (this.children.length === 0 ? [this] : this.children).map((g) => g.value)
   }
 }

--- a/cucumber-expressions/javascript/src/GroupBuilder.ts
+++ b/cucumber-expressions/javascript/src/GroupBuilder.ts
@@ -1,4 +1,5 @@
 import Group from './Group'
+import { RegExpExecArray } from 'regexp-match-indices'
 
 export default class GroupBuilder {
   public source: string
@@ -13,7 +14,6 @@ export default class GroupBuilder {
     const groupIndex = nextGroupIndex()
     const children = this.groupBuilders.map((gb) => gb.build(match, nextGroupIndex))
     const value = match[groupIndex] || undefined
-    // @ts-ignore
     const index = match.indices[groupIndex]
     const start = index ? index[0] : undefined
     const end = index ? index[1] : undefined

--- a/cucumber-expressions/javascript/src/GroupBuilder.ts
+++ b/cucumber-expressions/javascript/src/GroupBuilder.ts
@@ -1,5 +1,4 @@
 import Group from './Group'
-import RegexExecArray from './RegexExecArray'
 
 export default class GroupBuilder {
   public source: string
@@ -10,15 +9,15 @@ export default class GroupBuilder {
     this.groupBuilders.push(groupBuilder)
   }
 
-  public build(match: RegexExecArray, nextGroupIndex: () => number): Group {
+  public build(match: RegExpExecArray, nextGroupIndex: () => number): Group {
     const groupIndex = nextGroupIndex()
     const children = this.groupBuilders.map((gb) => gb.build(match, nextGroupIndex))
-    return new Group(
-      match[groupIndex] || undefined,
-      match.index[groupIndex],
-      match.index[groupIndex] + (match[groupIndex] || '').length,
-      children
-    )
+    const value = match[groupIndex] || undefined
+    // @ts-ignore
+    const index = match.indices[groupIndex]
+    const start = index ? index[0] : undefined
+    const end = index ? index[1] : undefined
+    return new Group(value, start, end, children)
   }
 
   public setNonCapturing() {

--- a/cucumber-expressions/javascript/src/RegexExecArray.ts
+++ b/cucumber-expressions/javascript/src/RegexExecArray.ts
@@ -1,4 +1,0 @@
-export default interface RegexExecArray extends ReadonlyArray<string> {
-  index: ReadonlyArray<number>
-  input: string
-}

--- a/cucumber-expressions/javascript/src/TreeRegexp.ts
+++ b/cucumber-expressions/javascript/src/TreeRegexp.ts
@@ -1,18 +1,21 @@
 import GroupBuilder from './GroupBuilder'
-// @ts-ignore
-import Regex from 'becke-ch--regex--s0-0-v1--base--pl--lib'
-import RegexExecArray from './RegexExecArray'
 import Group from './Group'
 
 export default class TreeRegexp {
-  public regexp: RegExp
-  private regex: any
-  public groupBuilder: GroupBuilder
+  public readonly regexp: RegExp
+  public readonly groupBuilder: GroupBuilder
 
   constructor(regexp: RegExp | string) {
-    this.regexp = 'string' === typeof regexp ? new RegExp(regexp) : regexp
-    this.regex = new Regex(this.regexp.source, this.regexp.flags)
-    this.groupBuilder = TreeRegexp.createGroupBuilder(this.regex)
+    if (regexp instanceof RegExp) {
+      if (!regexp.flags.includes('d')) {
+        this.regexp = new RegExp(regexp.source, regexp.flags + 'd')
+      } else {
+        this.regexp = regexp
+      }
+    } else {
+      this.regexp = new RegExp(regexp, 'd')
+    }
+    this.groupBuilder = TreeRegexp.createGroupBuilder(this.regexp)
   }
 
   private static createGroupBuilder(regexp: RegExp) {
@@ -53,22 +56,22 @@ export default class TreeRegexp {
 
   private static isNonCapturing(source: string, i: number): boolean {
     // Regex is valid. Bounds check not required.
-    if (source[i + 1] != '?') {
+    if (source[i + 1] !== '?') {
       // (X)
       return false
     }
-    if (source[i + 2] != '<') {
+    if (source[i + 2] !== '<') {
       // (?:X)
       // (?=X)
       // (?!X)
       return true
     }
     // (?<=X) or (?<!X) else (?<name>X)
-    return source[i + 3] == '=' || source[i + 3] == '!'
+    return source[i + 3] === '=' || source[i + 3] === '!'
   }
 
   public match(s: string): Group | null {
-    const match: RegexExecArray = this.regex.exec(s)
+    const match = this.regexp.exec(s)
     if (!match) {
       return null
     }

--- a/cucumber-expressions/javascript/src/TreeRegexp.ts
+++ b/cucumber-expressions/javascript/src/TreeRegexp.ts
@@ -1,5 +1,6 @@
 import GroupBuilder from './GroupBuilder'
 import Group from './Group'
+import execWithIndices from 'regexp-match-indices'
 
 export default class TreeRegexp {
   public readonly regexp: RegExp
@@ -7,13 +8,9 @@ export default class TreeRegexp {
 
   constructor(regexp: RegExp | string) {
     if (regexp instanceof RegExp) {
-      if (!regexp.flags.includes('d')) {
-        this.regexp = new RegExp(regexp.source, regexp.flags + 'd')
-      } else {
-        this.regexp = regexp
-      }
+      this.regexp = regexp
     } else {
-      this.regexp = new RegExp(regexp, 'd')
+      this.regexp = new RegExp(regexp)
     }
     this.groupBuilder = TreeRegexp.createGroupBuilder(this.regexp)
   }
@@ -71,7 +68,7 @@ export default class TreeRegexp {
   }
 
   public match(s: string): Group | null {
-    const match = this.regexp.exec(s)
+    const match = execWithIndices(this.regexp, s)
     if (!match) {
       return null
     }

--- a/cucumber-expressions/javascript/test/TreeRegexpTest.ts
+++ b/cucumber-expressions/javascript/test/TreeRegexpTest.ts
@@ -120,8 +120,14 @@ describe('TreeRegexp', () => {
     assert.strictEqual(group.children.length, 1)
   })
 
-  it('works with flags', () => {
+  it('works with case insensitive flag', () => {
     const tr = new TreeRegexp(/HELLO/i)
+    const group = tr.match('hello')
+    assert.strictEqual(group.value, 'hello')
+  })
+
+  it('works with indices flag already present', () => {
+    const tr = new TreeRegexp(new RegExp('HELLO', 'id'))
     const group = tr.match('hello')
     assert.strictEqual(group.value, 'hello')
   })

--- a/cucumber-expressions/javascript/test/TreeRegexpTest.ts
+++ b/cucumber-expressions/javascript/test/TreeRegexpTest.ts
@@ -126,12 +126,6 @@ describe('TreeRegexp', () => {
     assert.strictEqual(group.value, 'hello')
   })
 
-  it('works with indices flag already present', () => {
-    const tr = new TreeRegexp(new RegExp('HELLO', 'id'))
-    const group = tr.match('hello')
-    assert.strictEqual(group.value, 'hello')
-  })
-
   it('empty capturing group', () => {
     const tr = new TreeRegexp(/()/)
     const group = tr.match('')

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,9 @@
       "name": "@cucumber/cucumber-expressions",
       "version": "12.1.1",
       "license": "MIT",
+      "dependencies": {
+        "regexp-match-indices": "1.0.2"
+      },
       "devDependencies": {
         "@types/js-yaml": "4.0.2",
         "@types/mocha": "8.2.3",
@@ -25348,6 +25351,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/regexp-match-indices": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regexp-match-indices/-/regexp-match-indices-1.0.2.tgz",
+      "integrity": "sha512-DwZuAkt8NF5mKwGGER1EGh2PRqyvhRhhLviH+R8y8dIuaQROlUfXjt4s9ZTXstIsSkptf06BSvwcEmmfheJJWQ==",
+      "dependencies": {
+        "regexp-tree": "^0.1.11"
+      }
+    },
+    "node_modules/regexp-tree": {
+      "version": "0.1.23",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.23.tgz",
+      "integrity": "sha512-+7HWfb4Bvu8Rs2eQTUIpX9I/PlQkYOuTNbRpKLJlQpSgwSkzFYh+pUj0gtvglnOZLKB6YgnIgRuJ2/IlpL48qw==",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
@@ -31784,6 +31803,7 @@
         "@types/node": "14.17.5",
         "js-yaml": "4.1.0",
         "mocha": "9.0.2",
+        "regexp-match-indices": "1.0.2",
         "ts-node": "10.1.0",
         "typescript": "4.3.5"
       },
@@ -50151,6 +50171,19 @@
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
       }
+    },
+    "regexp-match-indices": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regexp-match-indices/-/regexp-match-indices-1.0.2.tgz",
+      "integrity": "sha512-DwZuAkt8NF5mKwGGER1EGh2PRqyvhRhhLviH+R8y8dIuaQROlUfXjt4s9ZTXstIsSkptf06BSvwcEmmfheJJWQ==",
+      "requires": {
+        "regexp-tree": "^0.1.11"
+      }
+    },
+    "regexp-tree": {
+      "version": "0.1.23",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.23.tgz",
+      "integrity": "sha512-+7HWfb4Bvu8Rs2eQTUIpX9I/PlQkYOuTNbRpKLJlQpSgwSkzFYh+pUj0gtvglnOZLKB6YgnIgRuJ2/IlpL48qw=="
     },
     "regexp.prototype.flags": {
       "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,9 +78,6 @@
       "name": "@cucumber/cucumber-expressions",
       "version": "12.1.1",
       "license": "MIT",
-      "dependencies": {
-        "becke-ch--regex--s0-0-v1--base--pl--lib": "1.4.0"
-      },
       "devDependencies": {
         "@types/js-yaml": "4.0.2",
         "@types/mocha": "8.2.3",
@@ -31785,7 +31782,6 @@
         "@types/js-yaml": "4.0.2",
         "@types/mocha": "8.2.3",
         "@types/node": "14.17.5",
-        "becke-ch--regex--s0-0-v1--base--pl--lib": "1.4.0",
         "js-yaml": "4.1.0",
         "mocha": "9.0.2",
         "ts-node": "10.0.0",


### PR DESCRIPTION
## Summary

Use [RegExpExecArray#indices](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) to get the position of capture groups.

## Details

This PR removes the dependency on the [becke-ch--regex--s0-0-v1--base--pl--lib](https://www.npmjs.com/package/becke-ch--regex--s0-0-v1--base--pl--lib) library and uses `RegExpExecArray#indices` instead.

[RegExp Match Indices](https://github.com/tc39/proposal-regexp-match-indices) were introduced in v8 v9.0.259. The first Node.js release to use a v8 newer than that is [16.4.0](https://nodejs.org/en/download/releases/).

Since we cannot drop support for Node.js < 16.4.0 until 2023/2024, the implementation currently uses a [polyfill](https://github.com/rbuckton/regexp-match-indices).

## Motivation and Context

The main motivation for this change is to stop depending on http://www--s0-v1.becke.ch/tool/becke-ch--regex--s0-v1/becke-ch--regex--s0-0-v1--homepage--pl--client/, which seems to be a liability to depend on because it doesn't seem to have a public Git repo, except for [this fork](https://github.com/TheWorldTable/regexp-plus).

I would also expect this to be slightly more performant since it's based on a native implementation, but I doubt it will be significant for end users.

Also see https://github.com/cucumber/common/issues/300

## How Has This Been Tested?

The tests pass on Node v16.4.2, but I doubt it will pass on Node < 16.4.0 as explained above.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [x] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.

