### PR TITLE
Change StepDocument to have suggestion and segments

### DIFF
--- a/suggest/CHANGELOG.md
+++ b/suggest/CHANGELOG.md
@@ -9,7 +9,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Added `suggestion` string property on `StepDocument`
+  ([#1657](https://github.com/cucumber/common/pull/1657)
+   [aslakhellesoy])
+
 ### Changed
+
+* The `StepDocument` type has changed to `{ suggestion: string, segments: StepSegments }`
+  ([#1657](https://github.com/cucumber/common/pull/1657)
+   [aslakhellesoy])
 
 ### Deprecated
 

--- a/suggest/javascript/README.md
+++ b/suggest/javascript/README.md
@@ -40,10 +40,28 @@ to represent search results.
   | the weather forecast is {word}     |
 * When I type "cukes"
 * Then the suggestions should be:
-  | LSP Completion Snippet                                        |
-  | ------------------------------------------------------------- |
-  | I have ${1\|11,23\|} cukes in my ${2\|belly,suitcase,table\|} |
-  | I have ${1\|11,23\|} cukes on my ${2\|belly,suitcase,table\|} |
+  | LSP Completion Snippet          |
+  | ------------------------------- |
+  | I have {int} cukes in my {word} |
+  | I have {int} cukes on my {word} |
+
+### Example: Choices for a selected suggestion
+
+* Given the following Gherkin step texts exist:
+  | Gherkin Step                   |
+  | ------------------------------ |
+  | I have 23 cukes in my belly    |
+  | I have 11 cukes on my table    |
+  | I have 11 cukes in my suitcase |
+  | the weather forecast is rain   |
+* And the following Step Definitions exist:
+  | Step Definition Expression         |
+  | ---------------------------------- |
+  | I have {int} cukes in/on my {word} |
+  | the weather forecast is {word}     |
+* When I type "cukes"
+* And I select the 2nd snippet
+* Then the inserted text should be "I have ${1|11,23|} cukes on my ${2|belly,suitcase,table|}"
 
 LSP-compatible editors such as
 [Monaco Editor](https://microsoft.github.io/monaco-editor/) or 

--- a/suggest/javascript/README.md
+++ b/suggest/javascript/README.md
@@ -24,7 +24,7 @@ to represent search results.
 
 ## Rule: Suggestions are based on both steps and step definitions
 
-### Example: Two suggestions
+### Example: Two suggestions from Cucumber Expression
 
 * Given the following Gherkin step texts exist:
   | Gherkin Step                   |
@@ -34,16 +34,35 @@ to represent search results.
   | I have 11 cukes in my suitcase |
   | the weather forecast is rain   |
 * And the following Step Definitions exist:
-  | Step Definition Expression         |
+  | Cucumber Expression                |
   | ---------------------------------- |
   | I have {int} cukes in/on my {word} |
   | the weather forecast is {word}     |
 * When I type "cukes"
 * Then the suggestions should be:
-  | LSP Completion Snippet          |
+  | Suggestion                      |
   | ------------------------------- |
   | I have {int} cukes in my {word} |
   | I have {int} cukes on my {word} |
+
+### Example: Two suggestions from Regular Expression
+
+* Given the following Gherkin step texts exist:
+  | Gherkin Step                     |
+  | -------------------------------- |
+  | I have 23 cukes in my "belly"    |
+  | I have 11 cukes in my "suitcase" |
+* And the following Step Definitions exist:
+  | Regular Expression                              |
+  | ----------------------------------------------- |
+  | /I have (\d\d) cukes in my "(belly\|suitcase)"/ |
+* When I type "cukes"
+* Then the suggestions should be:
+  | Suggestion                 |
+  | -------------------------- |
+  | I have {} cukes in my "{}" |
+
+The parameters are not named, because the regular expression doesn't have named capture groups.
 
 ### Example: Choices for a selected suggestion
 
@@ -55,13 +74,13 @@ to represent search results.
   | I have 11 cukes in my suitcase |
   | the weather forecast is rain   |
 * And the following Step Definitions exist:
-  | Step Definition Expression         |
+  | Cucumber Expression                |
   | ---------------------------------- |
   | I have {int} cukes in/on my {word} |
   | the weather forecast is {word}     |
 * When I type "cukes"
 * And I select the 2nd snippet
-* Then the inserted text should be "I have ${1|11,23|} cukes on my ${2|belly,suitcase,table|}"
+* Then the LSP snippet should be "I have ${1|11,23|} cukes on my ${2|belly,suitcase,table|}"
 
 LSP-compatible editors such as
 [Monaco Editor](https://microsoft.github.io/monaco-editor/) or 

--- a/suggest/javascript/features/step_definitions/steps.ts
+++ b/suggest/javascript/features/step_definitions/steps.ts
@@ -1,7 +1,7 @@
 import { DataTable, Given, Then, When } from '@cucumber/cucumber'
 import World from '../support/World'
 import assert from 'assert'
-import { CucumberExpression, ExpressionFactory, ParameterTypeRegistry } from '@cucumber/cucumber-expressions'
+import { ExpressionFactory, ParameterTypeRegistry } from '@cucumber/cucumber-expressions'
 import bruteForceIndex from '../../test/bruteForceIndex'
 import buildStepDocuments from '../../src/buildStepDocuments'
 import { lspCompletionSnippet } from '../../src'

--- a/suggest/javascript/features/support/World.ts
+++ b/suggest/javascript/features/support/World.ts
@@ -1,6 +1,14 @@
-import { setWorldConstructor } from '@cucumber/cucumber'
+import { setWorldConstructor, defineParameterType } from '@cucumber/cucumber'
 import { Expression } from '@cucumber/cucumber-expressions'
-import { StepDocument } from '../../src/types'
+import { StepDocument } from '../../src'
+
+defineParameterType({
+  name: 'ordinal',
+  regexp: /(\d+)(?:st|nd|rd|th)/,
+  transformer(s) {
+    return +s - 1
+  },
+})
 
 export default class World {
   /**
@@ -16,7 +24,12 @@ export default class World {
   /**
    * The results of calling the index(text) function
    */
-  stepDocuments: readonly StepDocument[]
+  suggestedStepDocuments: readonly StepDocument[]
+
+  /**
+   * The index of the selected suggestion
+   */
+  selectedSuggestionIndex: number
 }
 
 setWorldConstructor(World)

--- a/suggest/javascript/src/StepDocumentBuilder.ts
+++ b/suggest/javascript/src/StepDocumentBuilder.ts
@@ -51,7 +51,7 @@ export default class StepDocumentBuilder {
       const suggestion = textOrIndexExpression
         .map((segment) => {
           if (typeof segment === 'number') {
-            return `{${this.parameterTypes[segment].name}}`
+            return `{${this.parameterTypes[segment].name || ''}}`
           } else {
             return segment
           }

--- a/suggest/javascript/src/lspCompletionSnippet.ts
+++ b/suggest/javascript/src/lspCompletionSnippet.ts
@@ -3,11 +3,11 @@
  *
  * @param expression the expression to generate the snippet from
  */
-import { StepDocument } from './types'
+import { StepSegments } from './types'
 
-export default function lspCompletionSnippet(stepDocument: StepDocument): string {
+export default function lspCompletionSnippet(stepSegments: StepSegments): string {
   let n = 1
-  return stepDocument
+  return stepSegments
     .map((segment) => (Array.isArray(segment) ? lspPlaceholder(n++, segment) : segment))
     .join('')
 }

--- a/suggest/javascript/src/types.ts
+++ b/suggest/javascript/src/types.ts
@@ -7,8 +7,26 @@
 export type Index = (text: string) => readonly StepDocument[]
 
 /**
- * A document that can be indexed.
+ * A document that can be indexed. It's recommended to index the segments rather than the suggestion.
+ * When indexing the segments, the nested arrays (representing choices) may be given lower weight
+ * than the string segments (which represent the "sentence")
  */
-export type StepDocument = readonly StepSegment[]
+export type StepDocument = {
+  /**
+   * The suggestion is what the user will see in the autocomplete.
+   */
+  suggestion: string
+
+  /**
+   * The segments are used to build the contents that will be inserted into the editor
+   * after selecting a suggestion.
+   *
+   * For LSP compatible editors, this can be formatted to an LSP snippet with the
+   * lspCompletionSnippet function.
+   */
+  segments: StepSegments
+}
+
+export type StepSegments = readonly StepSegment[]
 
 export type StepSegment = string | readonly string[]

--- a/suggest/javascript/test/StepDocumentBuilder.test.ts
+++ b/suggest/javascript/test/StepDocumentBuilder.test.ts
@@ -1,10 +1,10 @@
-import { CucumberExpression, ParameterTypeRegistry } from '@cucumber/cucumber-expressions'
+import { CucumberExpression, ParameterTypeRegistry, RegularExpression } from '@cucumber/cucumber-expressions'
 import assert from 'assert'
 import StepDocumentBuilder from '../src/StepDocumentBuilder'
 import { StepDocument } from '../src'
 
 describe('StepDocumentBuilder', () => {
-  it('builds step documents', () => {
+  it('builds step documents from CucumberExpression', () => {
     const registry = new ParameterTypeRegistry()
     const expression = new CucumberExpression('I have {int} cukes in/on my {word}', registry)
     const builder = new StepDocumentBuilder(expression)
@@ -20,6 +20,23 @@ describe('StepDocumentBuilder', () => {
       {
         suggestion: 'I have {int} cukes on my {word}',
         segments: ['I have ', ['42', '54'], ' cukes on my ', ['basket', 'belly', 'table']],
+      },
+    ]
+
+    assert.deepStrictEqual(builder.getStepDocuments(), expectedDocuments)
+  })
+
+  it('builds step documents from RegularExpression', () => {
+    const registry = new ParameterTypeRegistry()
+    const expression = new RegularExpression(/I have (\d\d) cukes in my "(belly|suitcase)"/, registry)
+    const builder = new StepDocumentBuilder(expression)
+    builder.update('I have 42 cukes in my "belly"')
+    builder.update('I have 54 cukes in my "suitcase"')
+
+    const expectedDocuments: StepDocument[] = [
+      {
+        suggestion: 'I have {} cukes in my "{}"',
+        segments: ['I have ', ['42', '54'], ' cukes in my "', ['belly', 'suitcase'], '"'],
       },
     ]
 

--- a/suggest/javascript/test/StepDocumentBuilder.test.ts
+++ b/suggest/javascript/test/StepDocumentBuilder.test.ts
@@ -1,21 +1,29 @@
 import { CucumberExpression, ParameterTypeRegistry } from '@cucumber/cucumber-expressions'
 import assert from 'assert'
 import StepDocumentBuilder from '../src/StepDocumentBuilder'
+import { StepDocument } from '../src'
 
 describe('StepDocumentBuilder', () => {
   it('builds step documents', () => {
     const registry = new ParameterTypeRegistry()
-
     const expression = new CucumberExpression('I have {int} cukes in/on my {word}', registry)
     const builder = new StepDocumentBuilder(expression)
     builder.update('I have 42 cukes in my belly')
     builder.update('I have 54 cukes on my table')
     builder.update('I have 54 cukes in my basket')
 
-    assert.deepStrictEqual(builder.getStepDocuments(), [
-      ['I have ', ['42', '54'], ' cukes in my ', ['basket', 'belly', 'table']],
-      ['I have ', ['42', '54'], ' cukes on my ', ['basket', 'belly', 'table']],
-    ])
+    const expectedDocuments: StepDocument[] = [
+      {
+        suggestion: 'I have {int} cukes in my {word}',
+        segments: ['I have ', ['42', '54'], ' cukes in my ', ['basket', 'belly', 'table']],
+      },
+      {
+        suggestion: 'I have {int} cukes on my {word}',
+        segments: ['I have ', ['42', '54'], ' cukes on my ', ['basket', 'belly', 'table']],
+      },
+    ]
+
+    assert.deepStrictEqual(builder.getStepDocuments(), expectedDocuments)
   })
 
   it('builds step documents with a max number of choices', () => {
@@ -28,9 +36,16 @@ describe('StepDocumentBuilder', () => {
     builder.update('I have 67 cukes in my belly')
     builder.update('I have 54 cukes in my basket')
 
-    assert.deepStrictEqual(builder.getStepDocuments(2), [
-      ['I have ', ['42', '54'], ' cukes in my ', ['basket', 'belly']],
-      ['I have ', ['42', '54'], ' cukes on my ', ['basket', 'belly']],
-    ])
+    const expectedDocuments: StepDocument[] = [
+      {
+        suggestion: 'I have {int} cukes in my {word}',
+        segments: ['I have ', ['42', '54'], ' cukes in my ', ['basket', 'belly']],
+      },
+      {
+        suggestion: 'I have {int} cukes on my {word}',
+        segments: ['I have ', ['42', '54'], ' cukes on my ', ['basket', 'belly']],
+      },
+    ]
+    assert.deepStrictEqual(builder.getStepDocuments(2), expectedDocuments)
   })
 })

--- a/suggest/javascript/test/bruteForceIndex.ts
+++ b/suggest/javascript/test/bruteForceIndex.ts
@@ -15,7 +15,7 @@ export default function bruteForceIndex(stepDocuments: readonly StepDocument[]):
 }
 
 function matches(stepDocument: StepDocument, predicate: (segment: string) => boolean): boolean {
-  return !!stepDocument.find((segment) =>
+  return !!stepDocument.segments.find((segment) =>
     typeof segment === 'string' ? predicate(segment) : !!segment.find(predicate)
   )
 }

--- a/suggest/javascript/test/fuseIndex.ts
+++ b/suggest/javascript/test/fuseIndex.ts
@@ -6,9 +6,9 @@ type Doc = {
 }
 
 export default function fuseIndex(stepDocuments: readonly StepDocument[]): Index {
-  const docs: Doc[] = stepDocuments.map((expression) => {
+  const docs: Doc[] = stepDocuments.map((stepDocument) => {
     return {
-      text: expression
+      text: stepDocument.segments
         .map((segment) => (typeof segment === 'string' ? segment : segment.join(' ')))
         .join(''),
     }

--- a/suggest/javascript/test/jsSearchIndex.ts
+++ b/suggest/javascript/test/jsSearchIndex.ts
@@ -7,10 +7,10 @@ type Doc = {
 }
 
 export default function fuseIndex(stepDocuments: readonly StepDocument[]): Index {
-  const docs: Doc[] = stepDocuments.map((expression, id) => {
+  const docs: Doc[] = stepDocuments.map((stepDocument, id) => {
     return {
       id,
-      text: expression
+      text: stepDocument.segments
         .map((segment) => (typeof segment === 'string' ? segment : segment.join(' ')))
         .join(''),
     }

--- a/suggest/javascript/test/lspSnippet.test.ts
+++ b/suggest/javascript/test/lspSnippet.test.ts
@@ -1,17 +1,17 @@
 import assert from 'assert'
 import lspCompletionSnippet from '../src/lspCompletionSnippet'
-import { StepDocument } from '../src'
+import { StepSegments } from '../src/types'
 
 describe('lspSnippet', () => {
   it('converts a PermutationExpression to an LSP snippet', () => {
-    const expression: StepDocument = [
+    const stepSegments: StepSegments = [
       'I have ',
       ['42', '54'],
       ' cukes in my ',
       ['basket', 'belly', 'table'],
     ]
     assert.strictEqual(
-      lspCompletionSnippet(expression),
+      lspCompletionSnippet(stepSegments),
       'I have ${1|42,54|} cukes in my ${2|basket,belly,table|}'
     )
   })


### PR DESCRIPTION
## Summary

Change the `StepDocument` so it is an object with a `suggestion` string and a `segments` array.

## Motivation and Context

We don't want to display the actual LSP snippet in the suggestions the user sees. The LSP snippet should never be
seen by users - it's only passed to the editor to build the inserted text.

By adding a `suggestion` string, we can display something nicer to the user, such as `I have {int} cukes in my {word}`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [x] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG accordingly.

