### PR TITLE
Add custom rendering to <Feature> component

### DIFF
--- a/react/javascript/src/components/customise/CustomRendering.tsx
+++ b/react/javascript/src/components/customise/CustomRendering.tsx
@@ -69,6 +69,14 @@ export interface ExamplesTableClasses {
   detailRow: string
 }
 
+export interface FeatureProps {
+  feature: messages.Feature
+}
+
+export interface FeatureClasses {
+  children: string
+}
+
 export interface KeywordClasses {
   keyword: string
 }
@@ -120,6 +128,7 @@ export interface CustomRenderingSupport {
   DocString?: Customised<DocStringProps, DocStringClasses>
   ErrorMessage?: Customised<ErrorMessageProps, ErrorMessageClasses>
   ExamplesTable?: Customised<ExamplesTableProps, ExamplesTableClasses>
+  Feature?: Customised<FeatureProps, FeatureClasses>
   Keyword?: Customised<any, KeywordClasses>
   Parameter?: Customised<ParameterProps, ParameterClasses>
   StatusIcon?: Customised<StatusIconProps, StatusIconClasses>

--- a/react/javascript/src/components/gherkin/Feature.module.scss
+++ b/react/javascript/src/components/gherkin/Feature.module.scss
@@ -1,0 +1,6 @@
+@import '../../styles/theming';
+
+.children {
+  padding: 0;
+  margin: 1em;
+}

--- a/react/javascript/src/components/gherkin/Feature.tsx
+++ b/react/javascript/src/components/gherkin/Feature.tsx
@@ -2,34 +2,31 @@ import React from 'react'
 import Tags from './Tags'
 import Description from './Description'
 import Scenario from './Scenario'
-import * as messages from '@cucumber/messages'
 import Rule from './Rule'
 import Background from './Background'
 import Title from './Title'
 import Keyword from './Keyword'
 import HighLight from '../app/HighLight'
+import { DefaultComponent, FeatureClasses, FeatureProps, useCustomRendering } from '../customise/CustomRendering'
+import defaultStyles from './Feature.module.scss'
 
-interface IProps {
-  feature: messages.Feature
-}
-
-const Feature: React.FunctionComponent<IProps> = ({ feature }) => {
+const DefaultRenderer: DefaultComponent<FeatureProps, FeatureClasses> = ({ feature, styles }) => {
   return (
     <section>
-      <Tags tags={feature.tags} />
+      <Tags tags={feature.tags}/>
       <Title header="h1" id={feature.name}>
         <Keyword>{feature.keyword}:</Keyword>
-        <HighLight text={feature.name} />
+        <HighLight text={feature.name}/>
       </Title>
-      <Description description={feature.description} />
-      <div className="cucumber-children">
+      <Description description={feature.description}/>
+      <div className={styles.children}>
         {(feature.children || []).map((child, index) => {
           if (child.background) {
-            return <Background key={index} background={child.background} />
+            return <Background key={index} background={child.background}/>
           } else if (child.scenario) {
-            return <Scenario key={index} scenario={child.scenario} />
+            return <Scenario key={index} scenario={child.scenario}/>
           } else if (child.rule) {
-            return <Rule key={index} rule={child.rule} />
+            return <Rule key={index} rule={child.rule}/>
           } else {
             throw new Error('Expected background, scenario or rule')
           }
@@ -38,5 +35,15 @@ const Feature: React.FunctionComponent<IProps> = ({ feature }) => {
     </section>
   )
 }
+
+const Feature: React.FunctionComponent<FeatureProps> & { DefaultRenderer: React.FunctionComponent<FeatureProps> } = (props) => {
+  const ResolvedRenderer = useCustomRendering<FeatureProps, FeatureClasses>(
+    'Feature',
+    defaultStyles,
+    DefaultRenderer
+  )
+  return <ResolvedRenderer {...props} />
+}
+Feature.DefaultRenderer = DefaultRenderer
 
 export default Feature

--- a/react/javascript/src/stories/ThemesAndCustomisation.stories.tsx
+++ b/react/javascript/src/stories/ThemesAndCustomisation.stories.tsx
@@ -13,11 +13,12 @@ import './custom-classes.scss'
 
 import attachments from '../../acceptance/attachments/attachments.feature'
 import rules from '../../acceptance/rules/rules.feature'
-import { TagsProps } from '../components/customise/CustomRendering'
+import { FeatureProps, TagsProps } from '../components/customise/CustomRendering'
 import Theme from '../components/customise/Theme'
 import DocString from '../components/gherkin/DocString'
 import CustomRendering from '../components/customise/CustomRendering'
 import Tags from '../components/gherkin/Tags'
+import Feature from '../components/gherkin/Feature'
 
 export default {
   title: 'Themes & Customisation',
@@ -75,7 +76,7 @@ Classes.args = {
   },
 }
 
-export const Components: Story = ({ support, tags }) => {
+export const CustomTagComponent: Story = ({ support, tags }) => {
   return (
     <>
       <h2>Tags with JIRA linking</h2>
@@ -85,7 +86,8 @@ export const Components: Story = ({ support, tags }) => {
     </>
   )
 }
-Components.args = {
+
+CustomTagComponent.args = {
   tags: [
     {
       location: {
@@ -124,6 +126,43 @@ Components.args = {
           return <li key={i}>{tag.name}</li>
         })}
       </ul>
+    ),
+  },
+}
+
+export const CustomFeatureComponent: Story = ({ support, feature }) => {
+  return (
+    <>
+      <h2>Feature with button on top</h2>
+      <CustomRendering support={support}>
+        <Feature feature={feature} />
+      </CustomRendering>
+    </>
+  )
+}
+
+const feature: messages.Feature = {
+  keyword: 'Feature',
+  name: 'My feature',
+  children: [],
+  tags: [],
+  location: {
+    column: 1,
+    line: 1,
+  },
+  description: 'This\nis\nthe\ndescription',
+  language: 'en'
+}
+
+CustomFeatureComponent.args = {
+  feature: feature,
+  support: {
+    // eslint-disable-next-line react/display-name
+    Feature: (props: FeatureProps) => (
+      <div>
+        <button>Click me</button>
+        <Feature.DefaultRenderer {...props} />
+      </div>
     ),
   },
 }

--- a/react/javascript/src/styles/styles.scss
+++ b/react/javascript/src/styles/styles.scss
@@ -28,12 +28,6 @@ $summary-border-color: rgba(0, 0, 0, 0.1);
   }
 }
 
-// TODO encapsulate in a component
-.cucumber-children {
-  padding: 0;
-  margin: 1em;
-}
-
 .cucumber-no-documents {
   font: 14px 'Open Sans', sans-serif;
 }


### PR DESCRIPTION
## Summary

Add custom rendering support for `<Feature>`

## Motivation and Context

I want to render a button/link on top of every feature that when clicked, displays an editor.

I exposed the `Feature.DefaultRenderer` so that the overriding component can still use the original. Is this something that we should do for the other components too?

## How Has This Been Tested?

Using storybook

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [x] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG accordingly.

