### PR TITLE
Expand template build infrastructure for Perl components

### DIFF
--- a/.templates/perl/Makefile
+++ b/.templates/perl/Makefile
@@ -1,0 +1,10 @@
+include default.mk
+
+default: test
+.PHONY: all test
+
+TESTDEPS := t/*.t
+
+test: $(TESTDEPS) .cpanfile_dependencies
+	PERL5LIB=./perl5/lib/perl5 prove -l
+

--- a/.templates/perl/cpanfile
+++ b/.templates/perl/cpanfile
@@ -1,0 +1,16 @@
+#!perl
+
+requires "perl", "5.12.0"; # Minimum Perl version
+requires "module-name", "minimum-version"; # other runtime dependency
+
+on 'test' => sub {
+    requires "Test2::V0";  # The test-library
+    # testing-only dependencies here
+};
+
+on 'develop' => sub {
+    # there are no specific development dependencies...
+    # here go dependencies which are targetted at developing
+    # or tests run at development time, while 'test' dependencies
+    # also apply at installation time
+};

--- a/.templates/perl/default.mk
+++ b/.templates/perl/default.mk
@@ -14,3 +14,48 @@ define berp-generate-parser =
 -! dotnet tool list --tool-path /usr/bin | grep "berp\s*$(BERP_VERSION)" && dotnet tool update Berp --version $(BERP_VERSION) --tool-path /usr/bin
 berp -g $(BERP_GRAMMAR) -t $< -o $@ --noBOM
 endef
+
+
+### Common targets for all functionalities implemented on Perl
+
+default: test
+.PHONY: default
+
+CHANGELOG.md: ../CHANGELOG.md
+	cp ../CHANGELOG.md CHANGELOG.md
+
+distribution: predistribution
+	PERL5LIB=$$PWD/perl5/lib/perl5 PATH=$$PATH:$$PWD/perl5/bin dzil test --release
+	PERL5LIB=$$PWD/perl5/lib/perl5 PATH=$$PATH:$$PWD/perl5/bin dzil build
+.PHONY: distribution
+
+publish: predistribution
+	PERL5LIB=$$PWD/perl5/lib/perl5 PATH=$$PATH:$$PWD/perl5/bin dzil release
+.PHONY: publish
+
+update-version:
+ifdef NEW_VERSION
+	echo $(NEW_VERSION) > VERSION
+else
+	@echo -e "\033[0;31mNEW_VERSION is not defined. Can't update version :-(\033[0m"
+	exit 1
+endif
+.PHONY: update-version
+
+.cpanfile_dependencies: cpanfile
+	cpanm --notest --local-lib ./perl5 --installdeps .
+	touch $@
+
+predistribution: test CHANGELOG.md
+# --notest to keep the number of dependencies low: it doesn't install the
+# testing dependencies of the dependencies.
+	cpanm --notest --local-lib ./perl5 --installdeps --with-develop .
+	cpanm --notest --local-lib ./perl5 'Dist::Zilla'
+	PERL5LIB=./perl5/lib/perl5 PATH=$$PATH:./perl5/bin dzil authordeps --missing | cpanm --notest --local-lib ./perl5
+	PERL5LIB=./perl5/lib/perl5 PATH=$$PATH:./perl5/bin dzil clean
+	@(git status --porcelain 2>/dev/null | grep "^??" | perl -ne\
+	    'die "The `release` target includes all files in the working directory. Please remove [$$_], or add it to .gitignore if it should be included\n" if s!.+ perl/(.+?)\n!$$1!')
+.PHONY: predistribution
+
+pre-release: update-version
+.PHONY: pre-release

--- a/.templates/perl/dist.ini
+++ b/.templates/perl/dist.ini
@@ -1,0 +1,34 @@
+# The name of the 'dist' (the base name of the release tarball)
+name             = Cucumber-Messages
+# A short description of the content of the dist
+abstract         = A library for (de) serializing Cucumber protocol messages
+# The main module presents the primary page shown on MetaCPAN.org for the dist
+main_module      = lib/Cucumber/Messages.pm
+# A list of authors, one author per 'author=' row
+author           = Erik Huelsmann <ehuels@gmail.com>
+author           = Cucumber Ltd
+license          = MIT
+is_trial         = 0
+copyright_holder = Erik Huelsmann, Cucumber Ltd
+
+[MetaResources]
+bugtracker.web    = https://github.com/cucumber/common/issues
+repository.url    = https://github.com/cucumber/messages-perl.git
+repository.web    = https://github.com/cucumber/messages-perl
+repository.type   = git
+
+[@Filter]
+-bundle=@Basic
+-remove=Readme
+-remove=ConfirmRelease
+-remove=License
+
+[MetaJSON]
+[MetaProvides::Package]
+[PkgVersion]
+[Prereqs::FromCPANfile]
+
+
+
+[Hook::VersionProvider]
+. = my $v = `cat ./VERSION`; chomp( $v ); $v;


### PR DESCRIPTION
Simply add generic configuration to spawn additional Perl subprojects off from. Using a PR because I can't commit directly to `main`.
