### PR TITLE
[gherkin-perl] Align dist.ini with messages-perl

### DIFF
--- a/gherkin/perl/dist.ini
+++ b/gherkin/perl/dist.ini
@@ -20,10 +20,15 @@ repository.type   = git
 -remove=Readme
 -remove=ConfirmRelease
 -remove=License
+-remove=GatherDir
 
 [MetaJSON]
+[MetaProvides::Package]
 [PkgVersion]
 [Prereqs::FromCPANfile]
+[Git::GatherDir]
+exclude_filename=VERSION
+exclude_filename=default.mk
 
 [Hook::VersionProvider]
 . = my $v = `cat ./VERSION`; chomp( $v ); $v;


### PR DESCRIPTION
Copy the 'release-includes-unversioned artifacts' risk mitigation
to gherkin-perl to get consistent packaging.
