### PR TITLE
Read Makefile build image version from CI config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /usr/bin/env bash
-BUILD_IMAGE ?= cucumber/cucumber-build:0.5.2
+BUILD_IMAGE ?= $(shell grep "image: cucumber/cucumber-build:" .circleci/config.yml | cut -c 16-)
 PACKAGES ?= messages \
 	message-streams \
 	gherkin \
@@ -59,6 +59,7 @@ push_subrepos:
 	touch $@
 
 docker-run:
+	[ "${BUILD_IMAGE}" ] || (echo "Build image version could not be read from .circleci/config.yml" && exit 1)
 	[ -d "${HOME}/.m2/repository" ] || mkdir -p "${HOME}/.m2/repository"
 	docker run \
 	  --publish "6006:6006" \


### PR DESCRIPTION
## Summary

This means we have a single source of truth for the build image version.

## Details

It's been duplicated in the CircleCI config and the Makefile, and the Makefile had drifted out of date. Now we're reading the value to use in the Makefile from the CircleCI config, so we only have to change it in on place.

## How Has This Been Tested?

I ran `make docker-run`

## Types of changes

- [x] Refactoring / tech debt / DX improvements
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).