### PR TITLE
[gherkin-perl] Release engineering stability improvements

### DIFF
--- a/.templates/perl/default.mk
+++ b/.templates/perl/default.mk
@@ -46,7 +46,7 @@ endif
 	cpanm --notest --local-lib ./perl5 --installdeps .
 	touch $@
 
-predistribution: test CHANGELOG.md
+predistribution: dist-clean test CHANGELOG.md
 # --notest to keep the number of dependencies low: it doesn't install the
 # testing dependencies of the dependencies.
 	cpanm --notest --local-lib ./perl5 --installdeps --with-develop .
@@ -62,3 +62,8 @@ pre-release: update-version
 
 post-release:
 .PHONY: post-release
+
+dist-clean: clean
+	rm -rf ./perl5
+
+.PHONY: dist-clean

--- a/gherkin/perl/Makefile
+++ b/gherkin/perl/Makefile
@@ -8,14 +8,12 @@ ASTS     = $(patsubst testdata/%.feature,acceptance/testdata/%.feature.ast.ndjso
 PICKLES  = $(patsubst testdata/%.feature,acceptance/testdata/%.feature.pickles.ndjson,$(GOOD_FEATURE_FILES))
 ERRORS   = $(patsubst testdata/%.feature,acceptance/testdata/%.feature.errors.ndjson,$(BAD_FEATURE_FILES))
 
-PERL_FILES = $(shell find . -name "*.pm")
-
 .DELETE_ON_ERROR:
 
 test: .built $(TOKENS) $(ASTS) $(PICKLES)
 	PERL5LIB=./perl5/lib/perl5 prove -l
 
-.built: .cpanfile_dependencies lib/Gherkin/Generated/Parser.pm lib/Gherkin/Generated/Languages.pm $(PERL_FILES) bin/gherkin-generate-tokens LICENSE.txt
+.built: .cpanfile_dependencies lib/Gherkin/Generated/Parser.pm lib/Gherkin/Generated/Languages.pm bin/gherkin-generate-tokens LICENSE.txt
 	@$(MAKE) --no-print-directory show-version-info
 	# add Perl-level unit tests
 	touch $@

--- a/gherkin/perl/default.mk
+++ b/gherkin/perl/default.mk
@@ -46,7 +46,7 @@ endif
 	cpanm --notest --local-lib ./perl5 --installdeps .
 	touch $@
 
-predistribution: test CHANGELOG.md
+predistribution: dist-clean test CHANGELOG.md
 # --notest to keep the number of dependencies low: it doesn't install the
 # testing dependencies of the dependencies.
 	cpanm --notest --local-lib ./perl5 --installdeps --with-develop .
@@ -62,3 +62,8 @@ pre-release: update-version
 
 post-release:
 .PHONY: post-release
+
+dist-clean: clean
+	rm -rf ./perl5
+
+.PHONY: dist-clean

--- a/messages/perl/default.mk
+++ b/messages/perl/default.mk
@@ -46,7 +46,7 @@ endif
 	cpanm --notest --local-lib ./perl5 --installdeps .
 	touch $@
 
-predistribution: test CHANGELOG.md
+predistribution: dist-clean test CHANGELOG.md
 # --notest to keep the number of dependencies low: it doesn't install the
 # testing dependencies of the dependencies.
 	cpanm --notest --local-lib ./perl5 --installdeps --with-develop .
@@ -62,3 +62,8 @@ pre-release: update-version
 
 post-release:
 .PHONY: post-release
+
+dist-clean: clean
+	rm -rf ./perl5
+
+.PHONY: dist-clean


### PR DESCRIPTION
## Summary

Make sure no stale dependencies are hanging around when creating a release.

## Details

Current process isn't stable enough as per #1723.

Closes #1723.