### PR TITLE
Add CucumberInfo/CucumberInfoBuilder

### DIFF
--- a/language-server/javascript/src/CucumberInfoStream.ts
+++ b/language-server/javascript/src/CucumberInfoStream.ts
@@ -1,65 +1,21 @@
 import { Transform, TransformCallback } from 'stream'
-import { buildStepDocuments } from '@cucumber/suggest'
-import { Envelope, StepDefinitionPatternType } from '@cucumber/messages'
-import {
-  Expression,
-  ExpressionFactory,
-  ParameterType,
-  ParameterTypeRegistry,
-} from '@cucumber/cucumber-expressions'
-import { walkGherkinDocument } from '@cucumber/gherkin-utils'
-import { CucumberInfo } from './makeCucumberInfo'
+import { Envelope } from '@cucumber/messages'
+import { CucumberInfoBuilder } from '@cucumber/language-service'
 
 export class CucumberInfoStream extends Transform {
-  private readonly parameterTypeRegistry = new ParameterTypeRegistry()
-  private readonly expressionFactory = new ExpressionFactory(this.parameterTypeRegistry)
-
-  private readonly expressions: Expression[] = []
-  private stepTexts: string[] = []
+  private readonly builder = new CucumberInfoBuilder()
 
   constructor() {
     super({ objectMode: true })
   }
 
   _transform(envelope: Envelope, _: BufferEncoding, callback: TransformCallback) {
-    if (envelope.parameterType) {
-      const { name, regularExpressions, useForSnippets, preferForRegularExpressionMatch } =
-        envelope.parameterType
-      this.parameterTypeRegistry.defineParameterType(
-        new ParameterType(
-          name,
-          regularExpressions,
-          Object,
-          () => undefined,
-          useForSnippets,
-          preferForRegularExpressionMatch
-        )
-      )
-    }
-    if (envelope.stepDefinition) {
-      const expr =
-        envelope.stepDefinition.pattern.type === StepDefinitionPatternType.CUCUMBER_EXPRESSION
-          ? envelope.stepDefinition.pattern.source
-          : new RegExp(envelope.stepDefinition.pattern.source)
-      const expression = this.expressionFactory.createExpression(expr)
-      this.expressions.push(expression)
-    }
-    if (envelope.gherkinDocument) {
-      const stepTexts = this.stepTexts
-      this.stepTexts = walkGherkinDocument(envelope.gherkinDocument, this.stepTexts, {
-        step(step, arr) {
-          return arr.concat(step.text)
-        },
-      })
-    }
+    this.builder.processEnvelope(envelope)
     callback()
   }
 
   _flush(callback: TransformCallback) {
-    const cucumberInfo: CucumberInfo = {
-      stepDocuments: buildStepDocuments(this.stepTexts, this.expressions),
-      expressions: this.expressions,
-    }
+    const cucumberInfo = this.builder.build()
     callback(null, cucumberInfo)
   }
 }

--- a/language-server/javascript/src/makeCucumberInfo.ts
+++ b/language-server/javascript/src/makeCucumberInfo.ts
@@ -1,14 +1,8 @@
 import { spawn } from 'child_process'
 import { pipeline, Writable } from 'stream'
 import { NdjsonToMessageStream } from '@cucumber/message-streams'
+import { CucumberInfo } from '@cucumber/language-service'
 import { CucumberInfoStream } from './CucumberInfoStream'
-import { StepDocument } from '@cucumber/suggest'
-import { Expression } from '@cucumber/cucumber-expressions'
-
-export type CucumberInfo = {
-  stepDocuments: readonly StepDocument[]
-  expressions: readonly Expression[]
-}
 
 export function makeCucumberInfo(command: string, args: string[]): Promise<CucumberInfo | null> {
   const cucumber = spawn(command, args)

--- a/language-server/javascript/test/CucumberInfoStream.test.ts
+++ b/language-server/javascript/test/CucumberInfoStream.test.ts
@@ -5,7 +5,7 @@ import { NdjsonToMessageStream } from '@cucumber/message-streams'
 import assert from 'assert'
 import { StepDocument } from '@cucumber/suggest'
 import { CucumberInfoStream } from '../src/CucumberInfoStream'
-import { CucumberInfo } from '../src/makeCucumberInfo'
+import { CucumberInfo } from '@cucumber/language-service'
 
 const pipeline = promisify(pipelineCb)
 

--- a/language-service/CHANGELOG.md
+++ b/language-service/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Add `CucumberInfoBuilder` and `CucumberInfo`
+
 ### Changed
 
 ### Deprecated

--- a/language-service/javascript/src/CucumberInfo.ts
+++ b/language-service/javascript/src/CucumberInfo.ts
@@ -1,0 +1,60 @@
+import { Expression, ExpressionFactory, ParameterType, ParameterTypeRegistry } from '@cucumber/cucumber-expressions'
+import { Envelope, StepDefinitionPatternType } from '@cucumber/messages'
+import { walkGherkinDocument } from '@cucumber/gherkin-utils'
+import { buildStepDocuments, StepDocument } from '@cucumber/suggest'
+
+export type CucumberInfo = {
+  stepDocuments: readonly StepDocument[]
+  expressions: readonly Expression[]
+}
+
+/**
+ * Builds CucumberInfo from Cucumber Messages.
+ */
+export class CucumberInfoBuilder {
+  private readonly parameterTypeRegistry = new ParameterTypeRegistry()
+  private readonly expressionFactory = new ExpressionFactory(this.parameterTypeRegistry)
+
+  private readonly expressions: Expression[] = []
+  private stepTexts: string[] = []
+
+  processEnvelope(envelope: Envelope): void {
+    if (envelope.parameterType) {
+      const { name, regularExpressions, useForSnippets, preferForRegularExpressionMatch } =
+        envelope.parameterType
+      this.parameterTypeRegistry.defineParameterType(
+        new ParameterType(
+          name,
+          regularExpressions,
+          Object,
+          () => undefined,
+          useForSnippets,
+          preferForRegularExpressionMatch
+        )
+      )
+    }
+    if (envelope.stepDefinition) {
+      const expr =
+        envelope.stepDefinition.pattern.type === StepDefinitionPatternType.CUCUMBER_EXPRESSION
+          ? envelope.stepDefinition.pattern.source
+          : new RegExp(envelope.stepDefinition.pattern.source)
+      const expression = this.expressionFactory.createExpression(expr)
+      this.expressions.push(expression)
+    }
+    if (envelope.gherkinDocument) {
+      const stepTexts = this.stepTexts
+      this.stepTexts = walkGherkinDocument(envelope.gherkinDocument, this.stepTexts, {
+        step(step, arr) {
+          return arr.concat(step.text)
+        },
+      })
+    }
+  }
+
+  build(): CucumberInfo {
+    return {
+      stepDocuments: buildStepDocuments(this.stepTexts, this.expressions),
+      expressions: this.expressions,
+    }
+  }
+}

--- a/language-service/javascript/src/index.ts
+++ b/language-service/javascript/src/index.ts
@@ -1,3 +1,4 @@
 export * from './getGherkinSemanticTokens'
 export * from './getGherkinDiagnostics'
 export * from './getGherkinCompletionItems'
+export * from './CucumberInfo'


### PR DESCRIPTION
A `CucumberInfo` object is needed to power the Monaco editor. In a browser we don't have a (Node.js) message stream, but an array of messages loaded over HTTP. This PR extracts the logic from the `CucumberInfoStream` to a separate class.

