### PR TITLE
[gherkin-perl] Implement Gherkin on top of Cucumber::Messages

### DIFF
--- a/gherkin/CHANGELOG.md
+++ b/gherkin/CHANGELOG.md
@@ -13,6 +13,11 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ### Changed
 
+* [Perl] Changed API to pass around `Cucumber::Messages` instead of hashes
+  and increased minimum Perl version in accordance with `Cucumber::Messages`
+  (to 5.14; from 5.12) ([#1735](https://github.com/cucumber/common/pull/1735)
+  [ehuelsmann])
+
 ### Deprecated
 
 ### Removed

--- a/gherkin/perl/Makefile
+++ b/gherkin/perl/Makefile
@@ -1,9 +1,9 @@
 include default.mk
 
 ifeq ($(CI),)
-PERL5LIB  = $$PWD/../../messages/perl/lib:$$PWD/perl5/lib/perl5
-else
 PERL5LIB  = $$PWD/perl5/lib/perl5
+else
+PERL5LIB  = $$PWD/../../messages/perl/lib:$$PWD/perl5/lib/perl5
 endif
 PERL5PATH = $$PWD/perl5/bin
 

--- a/gherkin/perl/cpanfile
+++ b/gherkin/perl/cpanfile
@@ -1,7 +1,8 @@
 
-requires "perl", "5.12.0";
+requires "perl", "5.14.0";
 requires "Cpanel::JSON::XS";
 requires "Class::XSAccessor";
+requires "Cucumber::Messages";
 requires "Data::UUID";
 requires "Getopt::Long", "2.36";
 

--- a/gherkin/perl/lib/App/gherkin.pm
+++ b/gherkin/perl/lib/App/gherkin.pm
@@ -8,7 +8,7 @@ use open ':std', ':encoding(UTF-8)';
 
 use Class::XSAccessor accessors =>
   [ qw/out_handle include_source include_ast
-    include_pickles predictable_ids _json/, ];
+    include_pickles predictable_ids /, ];
 
 use Cpanel::JSON::XS;
 use Data::UUID;
@@ -25,7 +25,6 @@ sub new {
         include_ast     => 1,
         include_pickles => 1,
         predictable_ids => 0,
-        _json           => Cpanel::JSON::XS->new->canonical,
     }, $class;
 }
 
@@ -71,10 +70,9 @@ sub formatter {
     my ($self) = @_;
 
     my $fh   = $self->out_handle;
-    my $json = $self->_json;
     return sub {
         my $msg = shift;
-        print $fh $json->encode( $msg ) . "\n";
+        print $fh $msg->to_json . "\n";
     };
 }
 

--- a/gherkin/perl/lib/Gherkin.pm
+++ b/gherkin/perl/lib/Gherkin.pm
@@ -142,12 +142,15 @@ and compiler as developed by the Cucumber project
 Gherkin is a simple language, with a formal specification. The parser
 in this implementation is generated off the official language grammar.
 
+B<NOTE> Versions 21 and lower of this library used to send hashes to
+the C<$sink>, whereas the current version sends L<Cucumber::Messages>.
+
 =head1 OVERVIEW
 
 The Cucumber toolkit consists of a set of tools which form a pipe line:
 each consumes and produces protobuf messages
-(L<https://github.com/cucumber/messages/messages.proto>). These messages
-are either use ndjson or binary formatting.
+(See L<https://github.com/cucumber/common/tree/main/messages>). Messages
+use ndjson formatting.
 
 The start of the pipeline is the Gherkin language parser. C<Gherkin>
 implements that functionality in Perl. It's the first building block in
@@ -166,18 +169,18 @@ Accepted C<%options> are:
 =item include_source
 
 Boolean. Indicates whether the text of the source document is to be included
-in the output stream using a Source message.
+in the output stream using a L<Source message|Cucumber::Messages/Cucumber::Messages::Source>.
 
 =item include_ast
 
 Boolean. Indicates whether the parsed source (AST or Abstract Syntax Tree) is
-to be included in the output stream using a GherkinDocument message.
+to be included in the output stream using a L<GherkinDocument message|Cucumber::Messages/Cucumber::Messages::GherkinDocument>.
 
 =item include_pickles
 
 Boolean. Indicates whether the expanded-and-interpolated (executable)
 scenarios are to be included in the output stream using
-Pickle messages.
+L<Pickle messages|Cucumber::Messages/Cucumber::Messages::Pickle>.
 
 =back
 
@@ -189,7 +192,8 @@ for each of the paths in the arrayref C<$paths>.
 C<$id_gen> is a coderef to a function generating unique
 IDs which messages in the output stream can use to refer to other content
 in the stream. C<$sink> is a coderef to a function taking the next message
-in the stream as its argument.
+in the stream as its argument. Each message is encapsulated in an
+L<Envelope message|Cucumber::Messages/Cucumber::Messages::Envelope>.
 
 C<%options> are passed to C<new>.
 
@@ -201,19 +205,12 @@ C<%options> are passed to C<new>.
 Generates a stream of AST and pickle messages sent to C<$sink>. The source
 text in the message's C<data> attribute is assumed to be C<utf8> or C<UTF-8>
 encoded. The document header is scanned for an C<# encoding: ...> instruction.
-If one is found, the text is recoded from that encoding into UTF-8.
+If one is found, the text is recoded from that encoding into Perl's internal
+Unicode representation.
 
-The data in the C<source> message sent to the sink always is UTF-8 encoded.
-
-C<$source_msg> is a hash with the following structure:
-
-  {
-    source => {
-      data => 'feature content',
-      uri => 'e.g. path to source',
-      media_type => 'text/x.cucumber.gherkin+plain',
-    }
-  }
+The L<Source|Cucumber::Messages/Cucumber::Messages::Source> message sent to
+the sink is wrapped in an envelope which has a C<to_json> method to create
+UTF-8 encoded L<NDJSON|http://ndjson.org/> output.
 
 C<$id_gen> and C<$sink> are as documented in C<from_paths>.
 
@@ -222,10 +219,10 @@ C<$id_gen> and C<$sink> are as documented in C<from_paths>.
 
 Please see the included LICENSE.txt for the canonical version. In summary:
 
-The MIT License (MIT)
+  The MIT License (MIT)
 
-Copyright (c) 2020-2021 Erik Huelsmann
-Copyright (c) 2016      Peter Sergeant
+  Copyright (c) 2020-2021 Erik Huelsmann
+  Copyright (c) 2016      Peter Sergeant
 
 This work is a derivative of work that is:
 Copyright (c) 2014-2016 Cucumber Ltd, Gaspar Nagy

--- a/gherkin/perl/lib/Gherkin/AstBuilder.pm
+++ b/gherkin/perl/lib/Gherkin/AstBuilder.pm
@@ -4,6 +4,8 @@ use strict;
 use warnings;
 use Scalar::Util qw(reftype);
 
+use Cucumber::Messages;
+
 use Gherkin::Exceptions;
 use Gherkin::AstNode;
 
@@ -54,13 +56,11 @@ sub end_rule {
 sub build {
     my ( $self, $token ) = @_;
     if ( $token->matched_type eq 'Comment' ) {
-        push(
-            @{ $self->{'comments'} },
-            {
+        push @{ $self->{'comments'} },
+            Cucumber::Messages::Comment->new(
                 location => $self->get_location($token),
                 text     => $token->matched_text
-            }
-        );
+            );
     } else {
         $self->current_node->add( $token->matched_type, $token );
     }
@@ -77,14 +77,10 @@ sub get_location {
     use Carp qw/confess/;
     confess "What no token?" unless $token;
 
-    if ( !defined $column ) {
-        return $token->location;
-    } else {
-        return {
-            line   => $token->location->{'line'},
-            column => $column
-        };
-    }
+    return Cucumber::Messages::Location->new(
+        line   => $token->location->{'line'},
+        column => $column // $token->location->{'column'}
+        );
 }
 
 sub get_tags {
@@ -95,15 +91,12 @@ sub get_tags {
 
     for my $token ( @{ $tags_node->get_tokens('TagLine') } ) {
         for my $item ( @{ $token->matched_items } ) {
-            push(
-                @tags,
-                {
+            push @tags,
+                Cucumber::Messages::Tag->new(
                     id       => $self->next_id,
-                    location =>
-                      $self->get_location( $token, $item->{'column'} ),
-                    name => $item->{'text'}
-                }
-            );
+                    location => $self->get_location( $token, $item->{'column'} ),
+                    name     => $item->{'text'}
+                );
         }
     }
 
@@ -115,14 +108,11 @@ sub get_table_rows {
     my @rows;
 
     for my $token ( @{ $node->get_tokens('TableRow') } ) {
-        push(
-            @rows,
-            {
-                id       => $self->next_id,
-                location => $self->get_location($token),
-                cells    => $self->get_cells($token)
-            }
-        );
+        push @rows, Cucumber::Messages::TableRow->new(
+            id       => $self->next_id,
+            location => $self->get_location($token),
+            cells    => $self->get_cells($token)
+            );
     }
 
     $self->ensure_cell_count( \@rows );
@@ -136,12 +126,12 @@ sub ensure_cell_count {
     my $cell_count;
 
     for my $row (@$rows) {
-        my $this_row_count = @{ $row->{'cells'} };
+        my $this_row_count = @{ $row->cells };
         $cell_count = $this_row_count unless defined $cell_count;
         unless ( $cell_count == $this_row_count ) {
             Gherkin::Exceptions::AstBuilder->throw(
                 "inconsistent cell count within the table",
-                $row->{'location'} );
+                $row->location );
         }
     }
 }
@@ -150,16 +140,13 @@ sub get_cells {
     my ( $self, $table_row_token ) = @_;
     my @cells;
     for my $cell_item ( @{ $table_row_token->matched_items } ) {
-        push(
-            @cells,
-            $self->reject_nones(
-                {
-                    location => $self->get_location(
-                        $table_row_token, $cell_item->{'column'}
-                        ),
-                    value => $cell_item->{'text'}
-                })
-        );
+        push @cells,
+            Cucumber::Messages::TableCell->new(
+                location => $self->get_location(
+                    $table_row_token, $cell_item->{'column'}
+                ),
+                value => $cell_item->{'text'}
+            );
     }
 
     return \@cells;
@@ -167,20 +154,6 @@ sub get_cells {
 
 sub get_description { return ($_[1]->get_single('Description') || '') }
 sub get_steps       { return $_[1]->get_items('Step') }
-
-sub reject_nones {
-    my ( $self, $values ) = @_;
-
-    my $defined_only = {};
-    for my $key ( keys %$values ) {
-        my $value = $values->{$key};
-        if (defined $value) {
-            $defined_only->{$key} = $value;
-        }
-    }
-
-    return $defined_only;
-}
 
 sub next_id {
     my $self = shift;
@@ -195,16 +168,14 @@ sub transform_node {
         my $data_table = $node->get_single('DataTable') || undef;
         my $doc_string = $node->get_single('DocString') || undef;
 
-        return $self->reject_nones(
-            {
-                id        => $self->next_id,
-                location  => $self->get_location($step_line),
-                keyword   => $step_line->matched_keyword,
-                text      => $step_line->matched_text,
-                docString => $doc_string,
-                dataTable => $data_table,
-            }
-        );
+        return Cucumber::Messages::Step->new(
+            id         => $self->next_id,
+            location   => $self->get_location($step_line),
+            keyword    => $step_line->matched_keyword,
+            text       => $step_line->matched_text,
+            doc_string => $doc_string,
+            data_table => $data_table,
+            );
     } elsif ( $node->rule_type eq 'DocString' ) {
         my $separator_token = $node->get_tokens('DocStringSeparator')->[0];
         my $media_type      = $separator_token->matched_text;
@@ -212,37 +183,31 @@ sub transform_node {
         my $line_tokens     = $node->get_tokens('Other');
         my $content = join( "\n", map { $_->matched_text } @$line_tokens );
 
-        return $self->reject_nones(
-            {
-                location    => $self->get_location($separator_token),
-                content     => $content,
-                mediaType   => ($media_type eq '' ) ? undef : $media_type,
-                delimiter   => $delimiter
-            }
+        return Cucumber::Messages::DocString->new(
+            location    => $self->get_location($separator_token),
+            content     => $content,
+            media_type  => ($media_type eq '' ) ? undef : $media_type,
+            delimiter   => $delimiter
             );
     } elsif ( $node->rule_type eq 'DataTable' ) {
         my $rows = $self->get_table_rows($node);
-        return $self->reject_nones(
-            {
-                location => $rows->[0]->{'location'},
-                rows     => $rows
-            }
+        return Cucumber::Messages::DataTable->new(
+            location => $rows->[0]->{'location'},
+            rows     => $rows
         );
     } elsif ( $node->rule_type eq 'Background' ) {
         my $background_line = $node->get_token('BackgroundLine');
         my $description     = $self->get_description($node);
         my $steps           = $self->get_steps($node);
 
-        return $self->reject_nones(
-            {
-                id          => $self->next_id,
-                location    => $self->get_location($background_line),
-                keyword     => $background_line->matched_keyword,
-                name        => $background_line->matched_text,
-                description => $description,
-                steps       => $steps
-            }
-        );
+        return Cucumber::Messages::Background->new(
+            id          => $self->next_id,
+            location    => $self->get_location($background_line),
+            keyword     => $background_line->matched_keyword,
+            name        => $background_line->matched_text,
+            description => $description,
+            steps       => $steps
+            );
     } elsif ( $node->rule_type eq 'ScenarioDefinition' ) {
         my $tags          = $self->get_tags($node);
         my $scenario_node = $node->get_single('Scenario');
@@ -251,17 +216,15 @@ sub transform_node {
         my $steps         = $self->get_steps($scenario_node);
         my $examples      = $scenario_node->get_items('ExamplesDefinition');
 
-        return $self->reject_nones(
-            {
-                id          => $self->next_id,
-                tags        => $tags,
-                location    => $self->get_location($scenario_line),
-                keyword     => $scenario_line->matched_keyword,
-                name        => $scenario_line->matched_text,
-                description => $description,
-                steps       => $steps,
-                examples    => $examples
-            }
+        return Cucumber::Messages::Scenario->new(
+            id          => $self->next_id,
+            tags        => $tags,
+            location    => $self->get_location($scenario_line),
+            keyword     => $scenario_line->matched_keyword,
+            name        => $scenario_line->matched_text,
+            description => $description,
+            steps       => $steps,
+            examples    => $examples
             );
     } elsif ( $node->rule_type eq 'Rule' ) {
         my $header = $node->get_single('RuleHeader');
@@ -276,57 +239,51 @@ sub transform_node {
         }
         my $tags = $self->get_tags($header);
 
-        my $children = [];
+        my @children;
         my $background = $node->get_single('Background');
         if ( $background ) {
-            push( @{ $children }, { background => $background })
+            push @children,
+                Cucumber::Messages::RuleChild->new(
+                    background => $background
+                );
         }
-        for my $scenario_definition ( @{ $node->get_items('ScenarioDefinition') } ) {
-            push( @{ $children }, { scenario => $scenario_definition })
-        }
+        push @children, (
+            map {
+                Cucumber::Messages::RuleChild->new(
+                    scenario => $_
+                    )
+            } @{ $node->get_items('ScenarioDefinition') }
+            );
 
         my $description          = $self->get_description($header);
 
-        return $self->reject_nones(
-            {
-                id                  => $self->next_id,
-                tags                => $tags,
-                location            => $self->get_location($rule_line),
-                keyword             => $rule_line->matched_keyword,
-                name                => $rule_line->matched_text,
-                description         => $description,
-                children            => $children
-            }
+        return Cucumber::Messages::Rule->new(
+            id                  => $self->next_id,
+            tags                => $tags,
+            location            => $self->get_location($rule_line),
+            keyword             => $rule_line->matched_keyword,
+            name                => $rule_line->matched_text,
+            description         => $description,
+            children            => \@children
         );
     } elsif ( $node->rule_type eq 'ExamplesDefinition' ) {
-        my $tags           = $self->get_tags($node);
         my $examples_node  = $node->get_single('Examples');
         my $examples_line  = $examples_node->get_token('ExamplesLine');
         my $description    = $self->get_description($examples_node);
         my $examples_table = $examples_node->get_single('ExamplesTable');
+        my $rows           =
+            $examples_table ? $self->get_table_rows($examples_table) : undef;
+        my $tags           = $self->get_tags($node);
 
-        return $self->reject_nones(
-            {
-                id          => $self->next_id,
-                tags        => $tags,
-                location    => $self->get_location($examples_line),
-                keyword     => $examples_line->matched_keyword,
-                name        => $examples_line->matched_text,
-                description => $description,
-                tableHeader => $examples_table->{'tableHeader'} || undef,
-                tableBody   => $examples_table->{'tableBody'} || []
-            }
-        );
-    } elsif ( $node->rule_type eq 'ExamplesTable' ) {
-        my $rows = $self->get_table_rows($node);
-
-        my $table_header = shift(@$rows) if $rows;
-
-        return $self->reject_nones(
-            {
-                tableHeader => $table_header,
-                tableBody   => $rows
-            }
+        return Cucumber::Messages::Examples->new(
+            id          => $self->next_id,
+            tags        => $tags,
+            location    => $self->get_location($examples_line),
+            keyword     => $examples_line->matched_keyword,
+            name        => $examples_line->matched_text,
+            description => $description,
+            table_header => ($rows ? shift @{ $rows } : undef),
+            table_body   => ($rows ? $rows : [])
         );
     } elsif ( $node->rule_type eq 'Description' ) {
         my @description = @{ $node->get_tokens('Other') };
@@ -349,42 +306,48 @@ sub transform_node {
         }
         my $tags = $self->get_tags($header);
 
-        my $children = [];
+        my @children;
         my $background = $node->get_single('Background');
         if ( $background ) {
-            push( @{ $children }, { background => $background })
+            push @children,
+                Cucumber::Messages::FeatureChild->new(
+                    background => $background
+                );
         }
-        for my $scenario_definition ( @{ $node->get_items('ScenarioDefinition') } ) {
-            push( @{ $children }, { scenario => $scenario_definition })
-        }
-        for my $rule_definition ( @{ $node->get_items('Rule') } ) {
-            push( @{ $children }, { rule => $rule_definition })
-        }
+        push @children,
+            map {
+                Cucumber::Messages::FeatureChild->new(
+                    scenario => $_
+                    )
+            } @{ $node->get_items('ScenarioDefinition') };
+        push @children,
+            map {
+                Cucumber::Messages::FeatureChild->new(
+                    rule => $_
+                    )
+            } @{ $node->get_items('Rule') };
+
         my $description          = $self->get_description($header);
         my $language             = $feature_line->matched_gherkin_dialect;
 
-        return $self->reject_nones(
-            {
-                tags                => $tags,
-                location            => $self->get_location($feature_line),
-                language            => $language,
-                keyword             => $feature_line->matched_keyword,
-                name                => $feature_line->matched_text,
-                description         => $description,
-                children            => $children
-            }
-        );
+        return Cucumber::Messages::Feature->new(
+            tags        => $tags,
+            location    => $self->get_location($feature_line),
+            language    => $language,
+            keyword     => $feature_line->matched_keyword,
+            name        => $feature_line->matched_text,
+            description => $description,
+            children    => \@children
+            );
     } elsif ( $node->rule_type eq 'GherkinDocument' ) {
          my $feature = $node->get_single('Feature');
 
-         return {
-             gherkinDocument => $self->reject_nones(
-                 {
-                     uri                 => $self->{'uri'},
-                     feature             => $feature,
-                     comments            => $self->{'comments'},
-                 })
-         };
+         return Cucumber::Messages::Envelope->new(
+             gherkin_document => Cucumber::Messages::GherkinDocument->new(
+                 uri      => $self->{'uri'},
+                 feature  => $feature,
+                 comments => $self->{'comments'},
+             ));
     } else {
         return $node;
     }

--- a/gherkin/perl/lib/Gherkin/Pickles/Compiler.pm
+++ b/gherkin/perl/lib/Gherkin/Pickles/Compiler.pm
@@ -4,31 +4,37 @@ use strict;
 use warnings;
 use Scalar::Util qw(reftype);
 
+use Cucumber::Messages;
+
 sub compile {
-    my ( $class, $gherkin_document, $id_generator, $pickle_sink ) = @_;
+    my ( $class, $envelope, $id_generator, $pickle_sink ) = @_;
     my @pickles;
     $pickle_sink ||= sub { push @pickles, $_[0] };
 
-    my $feature = $gherkin_document->{'gherkinDocument'}->{'feature'};
-    my $language         = $feature->{'language'};
-    my $feature_tags     = $feature->{'tags'};
+    my $document = $envelope->gherkin_document;
+    my $feature  = $document->feature;
+
+    return [] if not defined $feature;
+
+    my $language         = $feature->language;
+    my $feature_tags     = $feature->tags;
     my $background_steps = [];
 
-    for my $child ( @{ $feature->{'children'} } ) {
-        if ( $child->{'background'} ) {
-            $background_steps = $child->{'background'}->{'steps'};
-        } elsif ( $child->{'scenario'} ) {
-            $class->_compile_scenario(
-                $gherkin_document->{'gherkinDocument'}->{'uri'},
+    for my $child ( @{ $feature->children } ) {
+        if ( my $background = $child->background ) {
+            $background_steps = $background->steps;
+        } elsif ( my $scenario = $child->scenario ) {
+            $class->_compile_scenario_outline(
+                $document->uri,
                 $feature_tags, $background_steps,
-                $child->{'scenario'}, $language, $id_generator,
+                $scenario, $language, $id_generator,
                 $pickle_sink
                 );
-        } elsif ( $child->{'rule'} ) {
+        } elsif ( my $rule = $child->rule ) {
             $class->_compile_rule(
-                $gherkin_document->{'gherkinDocument'}->{'uri'},
+                $document->uri,
                 $feature_tags, $background_steps,
-                $child->{'rule'}, $language, $id_generator,
+                $rule, $language, $id_generator,
                 $pickle_sink
                 );
         } else {
@@ -44,97 +50,80 @@ sub _pickle_steps {
     return [ map { $class->_pickle_step( $_, $id_generator ) } @$steps ];
 }
 
-sub reject_nones {
-    my ( $values ) = @_;
+sub _compile_scenario {
+    my ( $class, $uri, $tags, $background_steps,
+         $scenario, $variables, $values, $values_id,
+         $language, $id_generator, $pickle_sink )
+        = @_;
 
-    return [ grep { defined $_ } @$values ]
-        if reftype $values eq 'ARRAY';
-
-    my $defined_only = {};
-    for my $key ( keys %$values ) {
-        my $value = $values->{$key};
-        if (defined $value) {
-            $defined_only->{$key} = $value;
+    my @steps;
+    if ($scenario->steps and @{ $scenario->steps }) {
+        @steps = @{ $class->_pickle_steps($background_steps,
+                                          $id_generator) };
+        for my $step (@{ $scenario->steps } ) {
+            my $step_text =
+                $class->_interpolate( $step->text,
+                                      $variables, $values );
+            my $arguments =
+                $class->_create_pickle_arguments(
+                    $step,
+                    $variables, $values );
+            push @steps,
+                Cucumber::Messages::PickleStep->new(
+                    id         => $id_generator->(),
+                    text       => $step_text,
+                    argument   => $arguments,
+                    ast_node_ids => [ $step->id,
+                                      $values_id ? ($values_id,) : () ],
+                );
         }
     }
 
-    return $defined_only;
+    $pickle_sink->(
+        Cucumber::Messages::Envelope->new(
+            pickle => Cucumber::Messages::Pickle->new(
+                id   => $id_generator->(),
+                name => $class->_interpolate(
+                    $scenario->name,
+                    $variables, $values ),
+                language  => $language,
+                steps     => \@steps,
+                tags      => $class->_pickle_tags( $tags ),
+                uri       => $uri,
+                ast_node_ids=> [
+                    $scenario->id, $values_id ? ($values_id,) : ()
+                ]
+            )));
 }
 
-sub _compile_scenario {
+sub _compile_scenario_outline {
     my ( $class, $uri, $feature_tags, $background_steps,
          $scenario, $language, $id_generator, $pickle_sink )
         = @_;
 
-    my @examples = @{ $scenario->{'examples'} };
+    my @examples = @{ $scenario->examples };
     if (scalar @examples == 0) {
         # Create an empty example in order to iterate once below
-        push @examples, { tableHeader => {},
-                          tableBody   => [ { cells => [] } ]};
+        push @examples,
+            Cucumber::Messages::Examples->new(
+                table_header => Cucumber::Messages::TableRow->new(),
+                table_body   => [ Cucumber::Messages::TableRow->new() ]
+            );
     }
 
     for my $examples (@examples) {
-        my $variable_cells = $examples->{'tableHeader'}->{'cells'};
-
-        for my $values ( @{ $examples->{'tableBody'} || [] } ) {
-            my $value_cells = $values->{'cells'};
-            my @tags        = (
-                @{ $feature_tags || [] },
-                @{ $scenario->{'tags'} || [] },
-                @{ $examples->{'tags'} || [] }
+        my @tags        = (
+            @{ $feature_tags || [] },
+            @{ $scenario->tags || [] },
+            @{ $examples->tags || [] }
             );
-            my @steps;
-            if ($scenario->{'steps'} and @{ $scenario->{'steps'} }) {
-                @steps = @{ $class->_pickle_steps($background_steps,
-                                                  $id_generator) };
-                for my $step (@{ $scenario->{'steps'} } )
-                {
-                    my $step_text =
-                        $class->_interpolate( $step->{'text'},
-                                              $variable_cells, $value_cells, );
-                    my $arguments =
-                        $class->_create_pickle_arguments(
-                            $step,
-                            $variable_cells, $value_cells, );
-                    push(
-                        @steps,
-                        reject_nones(
-                            {
-                                id         => $id_generator->(),
-                                text       => $step_text,
-                                argument   => $arguments,
-                                astNodeIds => reject_nones(
-                                    [
-                                     $step->{'id'},
-                                     $values->{'id'}
-                                    ]),
-                            })
-                        );
-                }
-            }
-
-            $pickle_sink->(
-                {
-                    pickle =>
-                        reject_nones(
-                            {
-                                id   => $id_generator->(),
-                                name =>
-                                    $class->_interpolate(
-                                        $scenario->{'name'}, $variable_cells,
-                                        $value_cells,
-                                    ),
-                                language  => $language,
-                                steps     => \@steps,
-                                tags      => $class->_pickle_tags( \@tags ),
-                                uri       => $uri,
-                                astNodeIds=> reject_nones(
-                                    [
-                                     $scenario->{'id'},
-                                     $values->{'id'}
-                                    ])
-                            })
-                });
+        use Data::Dumper;
+        for my $values ( @{ $examples->table_body || [] } ) {
+            $class->_compile_scenario(
+                $uri, \@tags, $background_steps,
+                $scenario, $examples->table_header->cells, $values->cells, $values->id,
+                $language, $id_generator, $pickle_sink
+                );
         }
     }
 }
@@ -146,18 +135,18 @@ sub _compile_rule {
     my $background_steps = $feature_background_steps;
     my @tags = (
         @{ $feature_tags || [] },
-        @{ $rule_definition->{'tags'} || []}
+        @{ $rule_definition->tags || [] }
     );
 
-    for my $child ( @{ $rule_definition->{'children'} } ) {
-        if ( $child->{'background'} ) {
+    for my $child ( @{ $rule_definition->children } ) {
+        if ( my $background = $child->background ) {
             $background_steps =
                 [ @$feature_background_steps,
-                  @{ $child->{'background'}->{'steps'} } ];
-        } elsif ( $child->{'scenario'} ) {
-            $class->_compile_scenario(
+                  @{ $background->steps } ];
+        } elsif ( my $scenario = $child->scenario ) {
+            $class->_compile_scenario_outline(
                 $uri, \@tags, $background_steps,
-                $child->{'scenario'}, $language, $id_generator,
+                $scenario, $language, $id_generator,
                 $pickle_sink
                 );
         } else {
@@ -169,32 +158,34 @@ sub _compile_rule {
 sub _create_pickle_arguments {
     my ( $class, $argument, $variables, $values ) = @_;
 
-    if ( $argument->{'dataTable'} ) {
-        my $data = $argument->{'dataTable'};
-        my $table = { rows => [] };
-        for my $row ( @{ $data->{'rows'} || [] } ) {
-            my @cells = map {
-                reject_nones(
-                    {
-                        value => $class->_interpolate($_->{'value'},
-                                                      $variables, $values)
-                    })
-            } @{ $row->{'cells'} || [] };
-            push( @{ $table->{'rows'} }, { cells => \@cells } );
-        }
-        return {
-            dataTable => $table
-        };
-    } elsif ( $argument->{'docString'} ) {
-        my $docstring = $argument->{'docString'};
-        return {
-            docString => reject_nones({
-                mediaType => $class->_interpolate($docstring->{'mediaType'},
-                                                  $variables, $values),
-                content   => $class->_interpolate($docstring->{'content'},
-                                                  $variables, $values)
-            })
-        };
+    if ( my $data = $argument->data_table ) {
+        return Cucumber::Messages::PickleStepArgument->new(
+            data_table => Cucumber::Messages::PickleTable->new(
+                rows => [
+                    map {
+                        my $row = $_;
+                        Cucumber::Messages::PickleTableRow->new(
+                            cells => [
+                                map {
+                                    my $cell = $_;
+                                    Cucumber::Messages::PickleTableCell->new(
+                                        value => $class->_interpolate(
+                                            $cell->value, $variables, $values
+                                        ))
+                                } @{ $row->cells || [] }
+                            ]);
+                    } @{ $data->rows || [] }
+                ]
+            ));
+    } elsif ( $argument->doc_string ) {
+        my $docstring = $argument->doc_string;
+        return Cucumber::Messages::PickleStepArgument->new(
+            doc_string => Cucumber::Messages::PickleDocString->new(
+                media_type => $class->_interpolate( $docstring->media_type,
+                                                    $variables, $values),
+                content    => $class->_interpolate( $docstring->content,
+                                                    $variables, $values)
+            ));
     }
 
     return undef;
@@ -204,8 +195,8 @@ sub _interpolate {
     my ( $class, $name, $variable_cells, $value_cells ) = @_;
     my $n = 0;
     for my $variable_cell ( @{ $variable_cells || [] } ) {
-        my $from = '<' . $variable_cell->{'value'} . '>';
-        my $to   = $value_cells->[ $n++ ]->{'value'};
+        my $from = '<' . $variable_cell->value . '>';
+        my $to   = $value_cells->[ $n++ ]->value;
         $name =~ s/$from/$to/g if $name;
     }
     return $name;
@@ -214,16 +205,13 @@ sub _interpolate {
 sub _pickle_step {
     my ( $class, $step, $id_generator ) = @_;
 
-    return reject_nones({
-        text => $step->{'text'},
-        id   => $id_generator->(),
-        astNodeIds => [
-            $step->{'id'}
-            ],
-        argument =>
-          $class->_create_pickle_arguments( $step->{'argument'}, [], [],
-          ),
-    });
+    return Cucumber::Messages::PickleStep->new(
+        text         => $step->text,
+        id           => $id_generator->(),
+        ast_node_ids => [ $step->id ],
+        argument     => $class->_create_pickle_arguments(
+            $step, [], [],
+        ));
 }
 
 sub _pickle_tags {
@@ -233,10 +221,10 @@ sub _pickle_tags {
 
 sub _pickle_tag {
     my ( $class, $tag ) = @_;
-    return {
-        name      => $tag->{'name'},
-        astNodeId => $tag->{'id'}
-    };
+    return Cucumber::Messages::PickleTag->new(
+        name        => $tag->name,
+        ast_node_id => $tag->id
+    );
 }
 
 1;


### PR DESCRIPTION
## Summary

Change the Gherkin implementation to use real Cucumber::Messages instead of hashes that look like them.

## Details

Since Gherkin existed since way before Cucumber::Messages, its prior implementations didn't build upon them. With the recent implementation and release of Cucumber::Messages for Perl, now is the time to move the implementation over from the surrogates to the real thing.

## Motivation and Context

With this change, the Perl implementation of Gherkin moves closer to its equivalents in other languages.

## How Has This Been Tested?

The conformance tests.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.

