### PR TITLE
Monaco lsp fixes

### DIFF
--- a/language-service/CHANGELOG.md
+++ b/language-service/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* Fix insertion of completion items so it always replaces the full line rather than appending to the end.
+
 ## [0.1.0] - 2021-09-07
 
 ### Added

--- a/language-service/javascript/src/getGherkinCompletionItems.ts
+++ b/language-service/javascript/src/getGherkinCompletionItems.ts
@@ -14,18 +14,35 @@ export function getGherkinCompletionItems(
     return []
   }
   let text: string
+  let startCharacter: number
+  let endCharacter: number
   walkGherkinDocument(gherkinDocument, undefined, {
     step(step) {
       if (step.location.line === line + 1) {
         text = step.text
+        startCharacter = step.location.column + step.keyword.length - 1
+        endCharacter = startCharacter + text.length
       }
     },
   })
+  if (text === undefined) return []
   const stepDocuments = index(text)
   return stepDocuments.map((stepDocument) => ({
     label: stepDocument.suggestion,
-    insertText: lspCompletionSnippet(stepDocument.segments),
     insertTextFormat: InsertTextFormat.Snippet,
     kind: CompletionItemKind.Text,
+    textEdit: {
+      newText: lspCompletionSnippet(stepDocument.segments),
+      range: {
+        start: {
+          line,
+          character: startCharacter,
+        },
+        end: {
+          line,
+          character: endCharacter
+        }
+      }
+    }
   }))
 }

--- a/language-service/javascript/test/getGherkinCompletionItems.test.ts
+++ b/language-service/javascript/test/getGherkinCompletionItems.test.ts
@@ -23,9 +23,21 @@ describe('getGherkinCompletionItems', () => {
     const expectedCompletions: CompletionItem[] = [
       {
         label: 'I have {int} cukes in my belly',
-        insertText: 'I have ${1|42,98|} cukes in my belly',
         insertTextFormat: InsertTextFormat.Snippet,
         kind: CompletionItemKind.Text,
+        textEdit: {
+          newText: 'I have ${1|42,98|} cukes in my belly',
+          range: {
+            start: {
+              line: 2,
+              character: 10
+            },
+            end: {
+              line: 2,
+              character: 15
+            }
+          }
+        }
       },
     ]
     assert.deepStrictEqual(completions, expectedCompletions)

--- a/monaco/CHANGELOG.md
+++ b/monaco/CHANGELOG.md
@@ -11,11 +11,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Add an `editor` argument to the `configure` function
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+* Fix event listener for diagnostics by listening to the editor directly
 
 ## [0.1.0] - 2021-09-07
 

--- a/monaco/javascript/example/index.js
+++ b/monaco/javascript/example/index.js
@@ -30,9 +30,7 @@ const docs = buildStepDocuments(
 )
 const index = jsSearchIndex(docs)
 
-configure(monaco, index, expressions)
-
-monaco.editor.create(document.getElementById('root'), {
+const editor = monaco.editor.create(document.getElementById('root'), {
   value: `@foo
 Feature: Hello
   Scenario: Hi
@@ -45,4 +43,7 @@ Feature: Hello
   theme: 'vs-dark',
   // semantic tokens provider is disabled by default
   'semanticHighlighting.enabled': true
-});
+})
+
+configure(monaco, editor, index, expressions)
+

--- a/monaco/javascript/src/index.ts
+++ b/monaco/javascript/src/index.ts
@@ -1,44 +1,54 @@
-import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api'
+import { Expression } from '@cucumber/cucumber-expressions'
 import {
   getGherkinCompletionItems,
   getGherkinDiagnostics,
-  getGherkinSemanticTokens,
   getGherkinFormattingEdits,
+  getGherkinSemanticTokens,
   semanticTokenModifiers,
-  semanticTokenTypes
+  semanticTokenTypes,
 } from '@cucumber/language-service'
 import { Index } from '@cucumber/suggest'
-import { Expression } from '@cucumber/cucumber-expressions'
+import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api'
+import { editor } from 'monaco-editor/esm/vs/editor/editor.api'
 
 type Monaco = typeof monacoEditor
 
-export function configure(monaco: Monaco, index: Index | undefined, expressions: readonly Expression[]) {
+export function configure(
+  monaco: Monaco,
+  editor: editor.IStandaloneCodeEditor,
+  index: Index,
+  expressions: readonly Expression[]
+) {
   monaco.languages.register({ id: 'gherkin' })
 
   // Diagnostics (Syntax validation)
+  function setDiagnosticMarkers() {
+    const model = editor.getModel()
+    const gherkinSource = model.getValue()
+    const diagnostics = getGherkinDiagnostics(gherkinSource, expressions)
+    const markers: monacoEditor.editor.IMarkerData[] = diagnostics.map((d) => ({
+      severity: monaco.MarkerSeverity.Error,
+      message: d.message,
+      startLineNumber: d.range.start.line + 1,
+      startColumn: d.range.start.character + 1,
+      endLineNumber: d.range.end.line + 1,
+      endColumn: d.range.end.character + 1,
+    }))
+    monaco.editor.setModelMarkers(model, 'gherkin', markers)
+  }
 
-  monaco.editor.onDidCreateModel((model) => {
-    function validate() {
-      const gherkinSource = model.getValue()
-      const diagnostics = getGherkinDiagnostics(gherkinSource, expressions)
-      const markers: monacoEditor.editor.IMarkerData[] = diagnostics.map((d) => ({
-        severity: monaco.MarkerSeverity.Error,
-        message: d.message,
-        startLineNumber: d.range.start.line + 1,
-        startColumn: d.range.start.character + 1,
-        endLineNumber: d.range.end.line + 1,
-        endColumn: d.range.end.character + 1,
-      }))
-      monaco.editor.setModelMarkers(model, 'gherkin', markers)
-    }
-
-    let timeout: any
-    model.onDidChangeContent(() => {
-      // debounce
-      clearTimeout(timeout)
-      timeout = setTimeout(() => validate(), 500)
+  function requestValidation() {
+    window.requestAnimationFrame(() => {
+      setDiagnosticMarkers()
     })
-    validate()
+  }
+
+  requestValidation()
+
+  let validationTimeout: NodeJS.Timeout
+  editor.onDidChangeModelContent(() => {
+    clearTimeout(validationTimeout)
+    validationTimeout = setTimeout(requestValidation, 500)
   })
 
   // Syntax Highlighting (Semantic Tokens)
@@ -51,15 +61,16 @@ export function configure(monaco: Monaco, index: Index | undefined, expressions:
       }
     },
     releaseDocumentSemanticTokens: function () {
+      // no-op
     },
     provideDocumentSemanticTokens: function (model) {
       const gherkinSource = model.getValue()
       const tokens = getGherkinSemanticTokens(gherkinSource, expressions)
       const data = new Uint32Array(tokens.data)
       return {
-        data
+        data,
       }
-    }
+    },
   })
 
   // Auto-Complete
@@ -68,7 +79,11 @@ export function configure(monaco: Monaco, index: Index | undefined, expressions:
     provideCompletionItems: function (model, position) {
       const gherkinSource = model.getValue()
       const word = model.getWordUntilPosition(position)
-      const completionItems = getGherkinCompletionItems(gherkinSource, position.lineNumber - 1, index)
+      const completionItems = getGherkinCompletionItems(
+        gherkinSource,
+        position.lineNumber - 1,
+        index
+      )
       const range = {
         startLineNumber: position.lineNumber,
         endLineNumber: position.lineNumber,
@@ -82,9 +97,9 @@ export function configure(monaco: Monaco, index: Index | undefined, expressions:
           insertText: ci.insertText,
           insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
           range,
-        }))
+        })),
       }
-    }
+    },
   })
 
   // Document Formatting
@@ -92,15 +107,15 @@ export function configure(monaco: Monaco, index: Index | undefined, expressions:
     provideDocumentFormattingEdits: function (model) {
       const gherkinSource = model.getValue()
       const textEdits = getGherkinFormattingEdits(gherkinSource)
-      return textEdits.map(textEdit => ({
+      return textEdits.map((textEdit) => ({
         range: {
           startLineNumber: textEdit.range.start.line + 1,
           startColumn: textEdit.range.start.character + 1,
           endLineNumber: textEdit.range.end.line + 1,
           endColumn: textEdit.range.end.character + 1,
         },
-        text: textEdit.newText
+        text: textEdit.newText,
       }))
-    }
+    },
   })
 }


### PR DESCRIPTION
Two fixes:

* `@cucumber/language-service`: Fix completion items so they always replace the current line rather than appending at the end.
* `@cucumber/monaco`: Register diagnostic event on an editor instance so diagnostics are properly updated.