### PR TITLE
React customise gherkin document

### DIFF
--- a/react/CHANGELOG.md
+++ b/react/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Make `<GherkinDocument>` customiseable.
+
 ### Changed
 
 ### Deprecated

--- a/react/javascript/src/components/app/GherkinDocumentList.tsx
+++ b/react/javascript/src/components/app/GherkinDocumentList.tsx
@@ -78,7 +78,7 @@ export const GherkinDocumentList: React.FunctionComponent<IProps> = ({
               <AccordionItemPanel className={styles.accordionPanel}>
                 <UriContext.Provider value={doc.uri}>
                   {source.mediaType === messages.SourceMediaType.TEXT_X_CUCUMBER_GHERKIN_PLAIN ? (
-                    <GherkinDocument gherkinDocument={doc} />
+                    <GherkinDocument gherkinDocument={doc} source={source} />
                   ) : (
                     <MDG uri={doc.uri}>{source.data}</MDG>
                   )}

--- a/react/javascript/src/components/customise/CustomRendering.tsx
+++ b/react/javascript/src/components/customise/CustomRendering.tsx
@@ -78,6 +78,11 @@ export interface FeatureProps {
   feature: messages.Feature
 }
 
+export interface GherkinDocumentProps {
+  gherkinDocument: messages.GherkinDocument
+  source?: messages.Source
+}
+
 export interface GherkinStepProps {
   step: messages.Step
   hasExamples: boolean
@@ -159,6 +164,7 @@ export interface CustomRenderingSupport {
   Examples?: Customised<ExamplesProps, {}>
   ExamplesTable?: Customised<ExamplesTableProps, ExamplesTableClasses>
   Feature?: Customised<FeatureProps, {}>
+  GherkinDocument?: Customised<GherkinDocumentProps, {}>
   GherkinStep?: Customised<GherkinStepProps, {}>
   HookStep?: Customised<HookStepProps, {}>
   Keyword?: Customised<any, KeywordClasses>

--- a/react/javascript/src/components/gherkin/GherkinDocument.tsx
+++ b/react/javascript/src/components/gherkin/GherkinDocument.tsx
@@ -1,11 +1,12 @@
-import * as messages from '@cucumber/messages'
 import React from 'react'
 import { Feature } from './Feature'
+import { GherkinDocumentProps, useCustomRendering } from '../customise'
 
-interface IProps {
-  gherkinDocument: messages.GherkinDocument
+const DefaultRenderer: React.FunctionComponent<GherkinDocumentProps> = ({ gherkinDocument }) => {
+  return gherkinDocument.feature ? <Feature feature={gherkinDocument.feature} /> : null
 }
 
-export const GherkinDocument: React.FunctionComponent<IProps> = ({ gherkinDocument }) => {
-  return gherkinDocument.feature ? <Feature feature={gherkinDocument.feature} /> : null
+export const GherkinDocument: React.FunctionComponent<GherkinDocumentProps> = (props) => {
+  const ResolvedRenderer = useCustomRendering<GherkinDocumentProps, {}>('GherkinDocument', {}, DefaultRenderer)
+  return <ResolvedRenderer {...props} />
 }


### PR DESCRIPTION
## Summary

Make the `<GherkinDocument>` component customiseable

## Motivation and Context

I want to override it so I can display an editor based on `@cucumber/monaco`


