### PR TITLE
tag-expressions-python: Prepare release v4.0.1

### DIFF
--- a/tag-expressions/python/.bumpversion.cfg
+++ b/tag-expressions/python/.bumpversion.cfg
@@ -1,7 +1,6 @@
 [bumpversion]
-current_version = 4.0.0
+current_version = 4.0.1
 files = setup.py cucumber_tag_expressions/__init__.py .bumpversion.cfg pytest.ini
 commit = False
 tag = False
 allow_dirty = True
-

--- a/tag-expressions/python/.bumpversion.cfg
+++ b/tag-expressions/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.2
+current_version = 4.0.0
 files = setup.py cucumber_tag_expressions/__init__.py .bumpversion.cfg pytest.ini
 commit = False
 tag = False

--- a/tag-expressions/python/README.rst
+++ b/tag-expressions/python/README.rst
@@ -1,9 +1,9 @@
 Cucumber Tag Expressions for Python
 ===============================================================================
 
-.. image:: https://img.shields.io/travis/cucumber/tag-expressions-python/master.svg
-    :target: https://travis-ci.org/cucumber/tag-expressions-python
-    :alt: Travis CI Build Status
+.. image:: https://img.shields.io/circleci/build/github/cucumber/common/main?job=tag-expressions-python
+    :target: https://circleci.com/gh/cucumber/common
+    :alt: CI Build Status
 
 .. image:: https://img.shields.io/pypi/v/tag-expressions.svg
     :target: https://pypi.python.org/pypi/tag-expressions

--- a/tag-expressions/python/README.rst
+++ b/tag-expressions/python/README.rst
@@ -9,8 +9,8 @@ Cucumber Tag Expressions for Python
     :target: https://pypi.python.org/pypi/tag-expressions
     :alt: Latest Version
 
-.. image:: https://img.shields.io/pypi/l/tag-expressions.svg
-    :target: https://pypi.python.org/pypi/tag-expressions/
+.. image:: https://img.shields.io/pypi/l/cucumber-tag-expressions.svg
+    :target: https://pypi.python.org/pypi/cucumber-tag-expressions/
     :alt: License
 
 .. |logo| image:: https://github.com/cucumber-ltd/brand/raw/master/images/png/notm/cucumber-black/cucumber-black-128.png

--- a/tag-expressions/python/cucumber_tag_expressions/__init__.py
+++ b/tag-expressions/python/cucumber_tag_expressions/__init__.py
@@ -16,4 +16,4 @@ Theses selected items are normally included in a test run.
 from __future__ import absolute_import
 from .parser import parse, TagExpressionParser, TagExpressionError
 
-__version__ = "1.1.2"
+__version__ = "4.0.0"

--- a/tag-expressions/python/cucumber_tag_expressions/__init__.py
+++ b/tag-expressions/python/cucumber_tag_expressions/__init__.py
@@ -16,4 +16,4 @@ Theses selected items are normally included in a test run.
 from __future__ import absolute_import
 from .parser import parse, TagExpressionParser, TagExpressionError
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"

--- a/tag-expressions/python/pytest.ini
+++ b/tag-expressions/python/pytest.ini
@@ -21,7 +21,7 @@ testpaths     = tests
 python_files  = test_*.py
 addopts =
     --metadata PACKAGE_UNDER_TEST tag-expressions
-    --metadata PACKAGE_VERSION 4.0.0
+    --metadata PACKAGE_VERSION 4.0.1
     --html=build/testing/report.html --self-contained-html
     --junit-xml=build/testing/report.xml
 

--- a/tag-expressions/python/pytest.ini
+++ b/tag-expressions/python/pytest.ini
@@ -21,7 +21,7 @@ testpaths     = tests
 python_files  = test_*.py
 addopts =
     --metadata PACKAGE_UNDER_TEST tag-expressions
-    --metadata PACKAGE_VERSION 1.1.2
+    --metadata PACKAGE_VERSION 4.0.0
     --html=build/testing/report.html --self-contained-html
     --junit-xml=build/testing/report.xml
 

--- a/tag-expressions/python/setup.py
+++ b/tag-expressions/python/setup.py
@@ -50,7 +50,7 @@ def find_packages_by_root_package(where):
 # -----------------------------------------------------------------------------
 setup(
     name = "cucumber-tag-expressions",
-    version = "4.0.0",
+    version = "4.0.1",
     author = "Jens Engel",
     author_email = "jenisys@noreply.github.com",
     url = "https://github.com/cucumber/tag-expressions-python",

--- a/tag-expressions/python/tox.ini
+++ b/tag-expressions/python/tox.ini
@@ -22,7 +22,7 @@
 
 [tox]
 minversion   = 2.8
-envlist      = py27, py37, py36, py35, pypy
+envlist      = py39, py38, py27, pypy3
 skip_missing_interpreters = True
 
 


### PR DESCRIPTION
## Summary

Perform some cleanups and updates before a new release of this package can be published on https://pypi.org .

## Details

* FIXED: Out-of-date version info in some places
* UPDATED: `tox.ini` to use newer Python versions
* README: Use badge for CircleCI build server status (used in published version on pypi.org; was still using Travis CI)

PATCH RELEASE CONTAINS:

* FIX #1736 (with pull #1742 ; required by: `setuptools >= 58.0.2`)

## Motivation and Context

Prepare for next release of `tag-expressions-python`.

## How Has This Been Tested?

Normal test suite was run with tox.
BUT: Only cosmetic changes were performed here.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue) -- Minor cosmetic changes to next prepare release
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [x] The change has been ported to Python.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG accordingly.
