### PR TITLE
java: Use JUnit BOM to manage JUnit5 dependencies

### DIFF
--- a/create-meta/java/pom.xml
+++ b/create-meta/java/pom.xml
@@ -25,6 +25,18 @@
         <url>git://github.com/cucumber/create-meta-java.git</url>
     </scm>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.8.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.cucumber</groupId>
@@ -48,14 +60,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.8.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.8.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/cucumber-expressions/java/pom.xml
+++ b/cucumber-expressions/java/pom.xml
@@ -27,6 +27,18 @@
         <url>git://github.com/cucumber/cucumber-expressions-java.git</url>
     </scm>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.8.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apiguardian</groupId>
@@ -66,13 +78,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.8.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.8.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/html-formatter/java/pom.xml
+++ b/html-formatter/java/pom.xml
@@ -25,6 +25,18 @@
         <url>git://github.com/cucumber/html-formatter-java.git</url>
     </scm>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.8.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.cucumber</groupId>
@@ -40,13 +52,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.8.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.8.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/messages/java/pom.xml
+++ b/messages/java/pom.xml
@@ -25,6 +25,18 @@
         <url>git://github.com/cucumber/messages-java.git</url>
     </scm>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.8.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -35,7 +47,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.8.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/tag-expressions/java/pom.xml
+++ b/tag-expressions/java/pom.xml
@@ -25,6 +25,19 @@
         <url>git://github.com/cucumber/tag-expressions-java.git</url>
     </scm>
 
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.8.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -35,13 +48,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.8.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.8.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary

Unlike JUnit4, JUnit5 is a multi-module test framework. The version of these
modules should be kept in sync. This is best managed by using the JUnit Bill
of Materials.
When used in the dependency management section this allows individual JUnit
modules to be used without a version. They'll implicitly have the version
specified in the BOM.

By having a single version this should also ensure that tools like Renovate
will update all versions consistently.
