### PR TITLE
 Correctly match empty string. Fixes #1329.

### DIFF
--- a/cucumber-expressions/CHANGELOG.md
+++ b/cucumber-expressions/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * [JavaScript] Correctly match empty strings
   ([#1329](https://github.com/cucumber/common/issues/1329)
+   [#1753](https://github.com/cucumber/common/pull/1753)
    [aslakhellesoy])
 
 ## [12.1.3] - 2021-09-01

--- a/cucumber-expressions/CHANGELOG.md
+++ b/cucumber-expressions/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* [JavaScript] Correctly match empty strings
+  ([#1329](https://github.com/cucumber/common/issues/1329)
+   [aslakhellesoy])
+
 ## [12.1.3] - 2021-09-01
 
 ### Fixed

--- a/cucumber-expressions/go/regular_expression_test.go
+++ b/cucumber-expressions/go/regular_expression_test.go
@@ -112,6 +112,10 @@ func TestRegularExpression(t *testing.T) {
 		require.Equal(t, Match(t, `^a user( named "([^"]*)")?$`, "a user named \"Charlie\"")[0], "Charlie")
 	})
 
+	t.Run("matches empty string", func(t *testing.T) {
+		require.Equal(t, Match(t, `^The value equals "([^"]*)"$`, "The value equals \"\"")[0], "")
+	})
+
 	t.Run("matches capture group nested in optional one", func(t *testing.T) {
 		regexp := `^a (pre-commercial transaction |pre buyer fee model )?purchase(?: for \$(\d+))?$`
 		require.Equal(t, Match(t, regexp, "a purchase"), []interface{}{nil, nil})

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/RegularExpressionTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/RegularExpressionTest.java
@@ -105,6 +105,13 @@ public class RegularExpressionTest {
     }
 
     @Test
+    public void matches_empty_string() {
+        List<?> match = match(compile("^The value equals \"([^\"]*)\"$"), "The value equals \"\"", String.class);
+        assertEquals(String.class, match.get(0).getClass());
+        assertEquals("", match.get(0));
+    }
+
+    @Test
     public void uses_two_type_hints_to_resolve_anonymous_parameter_type() {
         List<?> match = match(compile("a (.*) and a (.*)"), "a 22 and a 33.5", Float.class, Double.class);
 

--- a/cucumber-expressions/javascript/src/GroupBuilder.ts
+++ b/cucumber-expressions/javascript/src/GroupBuilder.ts
@@ -13,7 +13,7 @@ export default class GroupBuilder {
   public build(match: RegExpExecArray, nextGroupIndex: () => number): Group {
     const groupIndex = nextGroupIndex()
     const children = this.groupBuilders.map((gb) => gb.build(match, nextGroupIndex))
-    const value = match[groupIndex] // || undefined
+    const value = match[groupIndex]
     const index = match.indices[groupIndex]
     const start = index ? index[0] : undefined
     const end = index ? index[1] : undefined

--- a/cucumber-expressions/javascript/src/GroupBuilder.ts
+++ b/cucumber-expressions/javascript/src/GroupBuilder.ts
@@ -13,7 +13,7 @@ export default class GroupBuilder {
   public build(match: RegExpExecArray, nextGroupIndex: () => number): Group {
     const groupIndex = nextGroupIndex()
     const children = this.groupBuilders.map((gb) => gb.build(match, nextGroupIndex))
-    const value = match[groupIndex] || undefined
+    const value = match[groupIndex] // || undefined
     const index = match.indices[groupIndex]
     const start = index ? index[0] : undefined
     const end = index ? index[1] : undefined

--- a/cucumber-expressions/javascript/test/RegularExpressionTest.ts
+++ b/cucumber-expressions/javascript/test/RegularExpressionTest.ts
@@ -16,37 +16,41 @@ describe('RegularExpression', () => {
   })
 
   it('does no transform by default', () => {
-    assert.deepStrictEqual(match(/(\d\d)/, '22')[0], '22')
+    assert.deepStrictEqual(match(/(\d\d)/, '22'), ['22'])
   })
 
   it('does not transform anonymous', () => {
-    assert.deepStrictEqual(match(/(.*)/, '22')[0], '22')
+    assert.deepStrictEqual(match(/(.*)/, '22'), ['22'])
   })
 
   it('transforms negative int', () => {
-    assert.deepStrictEqual(match(/(-?\d+)/, '-22')[0], -22)
+    assert.deepStrictEqual(match(/(-?\d+)/, '-22'), [-22])
   })
 
   it('transforms positive int', () => {
-    assert.deepStrictEqual(match(/(\d+)/, '22')[0], 22)
+    assert.deepStrictEqual(match(/(\d+)/, '22'), [22])
   })
 
   it('transforms float without integer part', () => {
     assert.deepStrictEqual(
-      match(new RegExp(`(${ParameterTypeRegistry.FLOAT_REGEXP.source})`), '.22')[0],
-      0.22
+      match(new RegExp(`(${ParameterTypeRegistry.FLOAT_REGEXP.source})`), '.22'),
+      [0.22]
     )
   })
 
   it('transforms float with sign', () => {
     assert.deepStrictEqual(
-      match(new RegExp(`(${ParameterTypeRegistry.FLOAT_REGEXP.source})`), '-1.22')[0],
-      -1.22
+      match(new RegExp(`(${ParameterTypeRegistry.FLOAT_REGEXP.source})`), '-1.22'),
+      [-1.22]
     )
   })
 
   it('returns null when there is no match', () => {
     assert.strictEqual(match(/hello/, 'world'), null)
+  })
+
+  it('matches empty string', () => {
+    assert.deepStrictEqual(match(/^The value equals "([^"]*)"$/, 'The value equals ""'), [''])
   })
 
   it('matches nested capture group without match', () => {

--- a/cucumber-expressions/javascript/test/TreeRegexpTest.ts
+++ b/cucumber-expressions/javascript/test/TreeRegexpTest.ts
@@ -129,16 +129,14 @@ describe('TreeRegexp', () => {
   it('empty capturing group', () => {
     const tr = new TreeRegexp(/()/)
     const group = tr.match('')
-    // TODO: Would expect the empty string here
-    assert.strictEqual(group.value, undefined)
+    assert.strictEqual(group.value, '')
     assert.strictEqual(group.children.length, 1)
   })
 
   it('empty look ahead', () => {
     const tr = new TreeRegexp(/(?<=)/)
     const group = tr.match('')
-    // TODO: Would expect the empty string here
-    assert.strictEqual(group.value, undefined)
+    assert.strictEqual(group.value, '')
     assert.strictEqual(group.children.length, 0)
   })
 

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/regular_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/regular_expression_spec.rb
@@ -36,6 +36,10 @@ module Cucumber
         expect( match(/hello/, "world") ).to be_nil
       end
 
+      it "matches empty string when there is an empty string match" do
+        expect( match(/^The value equals "([^"]*)"$/, 'The value equals ""') ).to eq([''])
+      end
+
       it "matches nested capture group without match" do
         expect( match(/^a user( named "([^"]*)")?$/, 'a user') ).to eq([nil])
       end


### PR DESCRIPTION
This is a fix for #1329.

The bug was only present in the JavaScript implementation, but tests have been added to all implementations.