### PR TITLE
create-meta/ruby: Create messages rather than plain hashes

### DIFF
--- a/create-meta/ruby/lib/cucumber/create_meta.rb
+++ b/create-meta/ruby/lib/cucumber/create_meta.rb
@@ -10,25 +10,25 @@ module Cucumber
     CI_DICT = JSON.parse(IO.read(File.join(File.dirname(__FILE__), "ciDict.json")))
 
     def create_meta(tool_name, tool_version, env = ENV)
-      {
-          protocol_version: Cucumber::Messages::VERSION,
-          implementation: {
-              name: tool_name,
-              version: tool_version
-          },
-          runtime: {
-              name: RUBY_ENGINE,
-              version: RUBY_VERSION
-          },
-          os: {
-              name: RbConfig::CONFIG['target_os'],
-              version: Sys::Uname.uname.version
-          },
-          cpu: {
-              name: RbConfig::CONFIG['target_cpu']
-          },
-          ci: detect_ci(env)
-      }
+      Cucumber::Messages::Meta.new(
+        protocol_version: Cucumber::Messages::VERSION,
+        implementation: Cucumber::Messages::Product.new(
+            name: tool_name,
+            version: tool_version
+        ),
+        runtime: Cucumber::Messages::Product.new(
+            name: RUBY_ENGINE,
+            version: RUBY_VERSION
+        ),
+        os: Cucumber::Messages::Product.new(
+            name: RbConfig::CONFIG['target_os'],
+            version: Sys::Uname.uname.version
+        ),
+        cpu: Cucumber::Messages::Product.new(
+            name: RbConfig::CONFIG['target_cpu']
+        ),
+        ci: detect_ci(env)
+      )
     end
 
     def detect_ci(env)
@@ -43,17 +43,17 @@ module Cucumber
       url = evaluate(ci_system['url'], env)
       return nil if url.nil?
 
-      {
-          url: url,
-          name: ci_name,
-          buildNumber: evaluate(ci_system['buildNumber'], env),
-          git: {
-              remote: remove_userinfo_from_url(evaluate(ci_system['git']['remote'], env)),
-              revision: evaluate(ci_system['git']['revision'], env),
-              branch: evaluate(ci_system['git']['branch'], env),
-              tag: evaluate(ci_system['git']['tag'], env),
-          }.delete_if {|k,v| v.nil?}
-      }
+      Cucumber::Messages::Ci.new(
+        url: url,
+        name: ci_name,
+        build_number: evaluate(ci_system['buildNumber'], env),
+        git: Cucumber::Messages::Git.new(
+          remote: remove_userinfo_from_url(evaluate(ci_system['git']['remote'], env)),
+          revision: evaluate(ci_system['git']['revision'], env),
+          branch: evaluate(ci_system['git']['branch'], env),
+          tag: evaluate(ci_system['git']['tag'], env),
+        )
+      )
     end
 
     def remove_userinfo_from_url(value)

--- a/create-meta/ruby/spec/cucumber/create_meta_spec.rb
+++ b/create-meta/ruby/spec/cucumber/create_meta_spec.rb
@@ -2,15 +2,35 @@ require 'cucumber/create_meta'
 
 describe 'create_meta' do
   it 'generates a Meta message with platform information' do
-    meta = Cucumber::CreateMeta.create_meta('cucumba-ruby', 'X.Y.Z')
+    meta = Cucumber::CreateMeta.create_meta('cucumba-ruby', 'X.Y.Z', [])
 
-    expect(meta[:protocol_version]).to match(/\d+\.\d+\.\d+/)
-    expect(meta[:implementation][:name]).to eq('cucumba-ruby')
-    expect(meta[:implementation][:version]).to eq('X.Y.Z')
-    expect(meta[:runtime][:name]).to match(/(jruby|ruby)/)
-    expect(meta[:runtime][:version]).to eq(RUBY_VERSION)
-    expect(meta[:os][:name]).to match(/.+/)
-    expect(meta[:os][:version]).to match(/.+/)
-    expect(meta[:cpu][:name]).to match(/.+/)
+    expect(meta.protocol_version).to match(/\d+\.\d+\.\d+/)
+    expect(meta.implementation.name).to eq('cucumba-ruby')
+    expect(meta.implementation.version).to eq('X.Y.Z')
+    expect(meta.runtime.name).to match(/(jruby|ruby)/)
+    expect(meta.runtime.version).to eq(RUBY_VERSION)
+    expect(meta.os.name).to match(/.+/)
+    expect(meta.os.version).to match(/.+/)
+    expect(meta.cpu.name).to match(/.+/)
+    expect(meta.ci).to be_nil
+  end
+
+  it 'generates a Meta message with CI information' do
+    env = {
+      'BUILD_URL' => 'url of the build',
+      'BUILD_NUMBER' => '42',
+      'GIT_URL' => 'url of git',
+      'GIT_COMMIT' => 'git_sha1',
+      'GIT_LOCAL_BRANCH' => 'main'
+    }
+
+    meta = Cucumber::CreateMeta.create_meta('cucumba-ruby', 'X.Y.Z', env)
+
+    expect(meta.ci).not_to be_nil
+    expect(meta.ci.url).to eq env['BUILD_URL']
+    expect(meta.ci.build_number).to eq env['BUILD_NUMBER']
+    expect(meta.ci.git.remote).to eq env['GIT_URL']
+    expect(meta.ci.git.revision).to eq env['GIT_COMMIT']
+    expect(meta.ci.git.branch).to eq env['GIT_LOCAL_BRANCH']
   end
 end


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

The ruby implementation of create-meta did not create proper messages but plain ruby hashes. That is responsible for generating ndjson with snake_case key for `protocol_version`.

## Details

<!--- Describe your changes in detail -->
I have converted the meta hashes into messages DTOs

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While working on reactivating the CCK for cucumber-ruby, it appears that meta.protocol_version was not camelized in the resulting ndjson

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I have used the existing spec, and added one to make sure the CI was also properly filled

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The change has been ported to Ruby.
- [x] I've added tests for my code.
- [ ] I have updated the CHANGELOG accordingly.

