### PR TITLE
messages/java: Exclude module info from shaded jar

### DIFF
--- a/messages/java/pom.xml
+++ b/messages/java/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.Automatic-Module-Name>io.cucumber.messages</project.Automatic-Module-Name>
-        <jackson-databind.version>2.12.5</jackson-databind.version>
+        <jackson-databind.version>2.13.0</jackson-databind.version>
     </properties>
 
     <scm>

--- a/messages/java/pom.xml
+++ b/messages/java/pom.xml
@@ -115,7 +115,21 @@
                                 <filter>
                                     <artifact>com.fasterxml.jackson.core:jackson-databind</artifact>
                                     <excludes>
-                                        <exclude>module-info.class</exclude>
+                                        <exclude>**/module-info.class</exclude>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>com.fasterxml.jackson.core:jackson-core</artifact>
+                                    <excludes>
+                                        <exclude>**/module-info.class</exclude>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>com.fasterxml.jackson.core:jackson-annotations</artifact>
+                                    <excludes>
+                                        <exclude>**/module-info.class</exclude>
                                         <exclude>META-INF/MANIFEST.MF</exclude>
                                     </excludes>
                                 </filter>


### PR DESCRIPTION
Jackson added more module infos to their project. These should not be included
in the shaded jar as this properly messes up encapsulation.