### PR TITLE
tag-expressions: support escape backslashes in tag expressions

### DIFF
--- a/tag-expressions/go/parser.go
+++ b/tag-expressions/go/parser.go
@@ -112,6 +112,7 @@ func tokenize(expr string) []string {
 	for _, c := range expr {
 		if unicode.IsSpace(c) {
 			collectToken()
+			escaped = false
 			continue
 		}
 
@@ -119,7 +120,12 @@ func tokenize(expr string) []string {
 
 		switch ch {
 		case "\\":
-			escaped = true
+			if escaped {
+				token.WriteString(ch)
+				escaped = false
+			} else {
+				escaped = true
+			}
 		case "(", ")":
 			if escaped {
 				token.WriteString(ch)
@@ -130,6 +136,7 @@ func tokenize(expr string) []string {
 			}
 		default:
 			token.WriteString(ch)
+			escaped = false
 		}
 	}
 
@@ -192,7 +199,12 @@ func (l *literalExpr) Evaluate(variables []string) bool {
 
 func (l *literalExpr) ToString() string {
 	return strings.Replace(
-		strings.Replace(l.value, "(", "\\(", -1),
+		strings.Replace(
+			strings.Replace(l.value, "\\", "\\\\", -1),
+			"(",
+			"\\(",
+			-1,
+		),
 		")",
 		"\\)",
 		-1,

--- a/tag-expressions/go/parser_test.go
+++ b/tag-expressions/go/parser_test.go
@@ -42,6 +42,16 @@ func TestParseForValidCases(t *testing.T) {
 			given:    "not a\\(\\) or b and not c or not d or e and f",
 			expected: "( ( ( not ( a\\(\\) ) or ( b and not ( c ) ) ) or not ( d ) ) or ( e and f ) )",
 		},
+		{
+			name:     "test escaping backslash",
+			given:    "(a\\\\ and b\\\\\\( and c\\\\\\) and d\\\\)",
+			expected: "( ( ( a\\\\ and b\\\\\\( ) and c\\\\\\) ) and d\\\\ )",
+		},
+		{
+			name:     "test backslash",
+			given:    "(a\\ and \\b) and c\\",
+			expected: "( ( a and b ) and c )",
+		},
 	}
 
 	for _, tc := range cases {
@@ -174,6 +184,32 @@ func TestParseForEvaluationErrors(t *testing.T) {
 				require.True(t, expr.Evaluate([]string{}))
 				require.True(t, expr.Evaluate([]string{"y"}))
 				require.True(t, expr.Evaluate([]string{"x"}))
+			},
+		},
+		{
+			name:  "evaluate expressions with escaped backslash",
+			given: "x\\\\ or(y\\\\\\)) or(z\\\\)",
+			expectations: func(t *testing.T, expr Evaluatable) {
+				require.False(t, expr.Evaluate([]string{}))
+				require.True(t, expr.Evaluate([]string{"x\\"}))
+				require.True(t, expr.Evaluate([]string{"y\\)"}))
+				require.True(t, expr.Evaluate([]string{"z\\"}))
+				require.False(t, expr.Evaluate([]string{"x"}))
+				require.False(t, expr.Evaluate([]string{"y)"}))
+				require.False(t, expr.Evaluate([]string{"z"}))
+			},
+		},
+		{
+			name:  "evaluate expressions with backslash",
+			given: "\\x or y\\ or z\\",
+			expectations: func(t *testing.T, expr Evaluatable) {
+				require.False(t, expr.Evaluate([]string{}))
+				require.True(t, expr.Evaluate([]string{"x"}))
+				require.True(t, expr.Evaluate([]string{"y"}))
+				require.True(t, expr.Evaluate([]string{"z"}))
+				require.False(t, expr.Evaluate([]string{"\\x"}))
+				require.False(t, expr.Evaluate([]string{"y\\"}))
+				require.False(t, expr.Evaluate([]string{"z\\"}))
 			},
 		},
 	}

--- a/tag-expressions/java/src/main/java/io/cucumber/tagexpressions/TagExpressionParser.java
+++ b/tag-expressions/java/src/main/java/io/cucumber/tagexpressions/TagExpressionParser.java
@@ -94,7 +94,7 @@ public final class TagExpressionParser {
         StringBuilder token = null;
         for (int i = 0; i < expr.length(); i++) {
             char c = expr.charAt(i);
-            if (ESCAPING_CHAR == c) {
+            if (ESCAPING_CHAR == c && !isEscaped) {
                 isEscaped = true;
             } else {
                 if (Character.isWhitespace(c)) { // skip
@@ -197,7 +197,7 @@ public final class TagExpressionParser {
 
         @Override
         public String toString() {
-            return value.replaceAll("\\(", "\\\\(").replaceAll("\\)", "\\\\)");
+            return value.replaceAll("\\\\", "\\\\\\\\").replaceAll("\\(", "\\\\(").replaceAll("\\)", "\\\\)");
         }
     }
 

--- a/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserParameterizedTest.java
+++ b/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserParameterizedTest.java
@@ -18,7 +18,11 @@ class TagExpressionParserParameterizedTest {
                 arguments("not a", "not ( a )"),
                 arguments("( a and b ) or ( c and d )", "( ( a and b ) or ( c and d ) )"),
                 arguments("not a or b and not c or not d or e and f", "( ( ( not ( a ) or ( b and not ( c ) ) ) or not ( d ) ) or ( e and f ) )"),
-                arguments("not a\\(1\\) or b and not c or not d or e and f", "( ( ( not ( a\\(1\\) ) or ( b and not ( c ) ) ) or not ( d ) ) or ( e and f ) )")
+                arguments("not a\\(1\\) or b and not c or not d or e and f", "( ( ( not ( a\\(1\\) ) or ( b and not ( c ) ) ) or not ( d ) ) or ( e and f ) )"),
+                arguments("a\\\\ and b", "( a\\\\ and b )"),
+                arguments("\\a and b\\ and c\\", "( ( a and b ) and c )"),
+                arguments("a\\\\\\( and b\\\\\\)", "( a\\\\\\( and b\\\\\\) )"),
+                arguments("(a and \\b)", "( a and b )")
         );
     }
 

--- a/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserTest.java
+++ b/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserTest.java
@@ -48,4 +48,22 @@ class TagExpressionParserTest {
         assertThat("Unexpected message", thrownException.getMessage(), is(equalTo("Tag expression 'or or' could not be parsed because of syntax error: expected operand")));
     }
 
+    @Test
+    void evaluates_expr_with_escaped_backslash() {
+        Expression expr = TagExpressionParser.parse("@a\\\\ or (@b\\\\\\)) or (@c\\\\)");
+        assertFalse(expr.evaluate(asList("@a @b) @c".split(" "))));
+        assertTrue(expr.evaluate(asList("@a\\".split(" "))));
+        assertTrue(expr.evaluate(asList("@b\\)".split(" "))));
+        assertTrue(expr.evaluate(asList("@c\\".split(" "))));
+    }
+
+    @Test
+    void evaluates_expr_with_backslash() {
+        Expression expr = TagExpressionParser.parse("@\\a or @b\\ or @c\\");
+        assertFalse(expr.evaluate(asList("@\\a @b\\ @c\\".split(" "))));
+        assertTrue(expr.evaluate(asList("@a".split(" "))));
+        assertTrue(expr.evaluate(asList("@b".split(" "))));
+        assertTrue(expr.evaluate(asList("@c".split(" "))));
+    }
+
 }

--- a/tag-expressions/javascript/src/index.ts
+++ b/tag-expressions/javascript/src/index.ts
@@ -84,7 +84,7 @@ function tokenize(expr: string): string[] {
   let token
   for (let i = 0; i < expr.length; i++) {
     const c = expr.charAt(i)
-    if ('\\' === c) {
+    if ('\\' === c && !isEscaped) {
       isEscaped = true
     } else {
       if (/\s/.test(c)) {
@@ -171,7 +171,7 @@ class Literal implements Node {
   }
 
   public toString() {
-    return this.value.replace(/\(/g, '\\(').replace(/\)/g, '\\)')
+    return this.value.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)')
   }
 }
 

--- a/tag-expressions/javascript/test/tag_expression_parser_test.ts
+++ b/tag-expressions/javascript/test/tag_expression_parser_test.ts
@@ -17,6 +17,13 @@ describe('TagExpressionParser', () => {
         'not a\\(\\) or b and not c or not d or e and f',
         '( ( ( not ( a\\(\\) ) or ( b and not ( c ) ) ) or not ( d ) ) or ( e and f ) )',
       ],
+      ['a\\\\ and b', '( a\\\\ and b )'],
+      ['\\a and b', '( a and b )'],
+      ['a\\ and b', '( a and b )'],
+      ['a and b\\', '( a and b )'],
+      ['( a and b\\\\)', '( a and b\\\\ )'],
+      ['a\\\\\\( and b\\\\\\)', '( a\\\\\\( and b\\\\\\) )'],
+      ['(a and \\b)', '( a and b )'],
       // a or not b
     ]
     tests.forEach(function (inOut) {
@@ -88,6 +95,28 @@ describe('TagExpressionParser', () => {
       assert.strictEqual(expr.evaluate([]), true)
       assert.strictEqual(expr.evaluate(['y']), true)
       assert.strictEqual(expr.evaluate(['x']), true)
+    })
+
+    it('evaluates expressions with escaped backslash', function () {
+      const expr = parse('x\\\\ or(y\\\\\\)) or(z\\\\)')
+      assert.strictEqual(expr.evaluate([]), false)
+      assert.strictEqual(expr.evaluate(['x\\']), true)
+      assert.strictEqual(expr.evaluate(['y\\)']), true)
+      assert.strictEqual(expr.evaluate(['z\\']), true)
+      assert.strictEqual(expr.evaluate(['x']), false)
+      assert.strictEqual(expr.evaluate(['y)']), false)
+      assert.strictEqual(expr.evaluate(['z']), false)
+    })
+
+    it('evaluates expressions with backslash', function () {
+      const expr = parse('\\x or y\\ or z\\')
+      assert.strictEqual(expr.evaluate([]), false)
+      assert.strictEqual(expr.evaluate(['x']), true)
+      assert.strictEqual(expr.evaluate(['y']), true)
+      assert.strictEqual(expr.evaluate(['z']), true)
+      assert.strictEqual(expr.evaluate(['\\x']), false)
+      assert.strictEqual(expr.evaluate(['y\\']), false)
+      assert.strictEqual(expr.evaluate(['z\\']), false)
     })
   })
 })

--- a/tag-expressions/ruby/lib/cucumber/tag_expressions/expressions.rb
+++ b/tag-expressions/ruby/lib/cucumber/tag_expressions/expressions.rb
@@ -3,7 +3,7 @@ module Cucumber
     # Literal expression node
     class Literal
       def initialize(value)
-        @value = value.gsub(/\\\(/, '(').gsub(/\\\)/, ')')
+        @value = value
       end
 
       def evaluate(variables)
@@ -11,7 +11,7 @@ module Cucumber
       end
 
       def to_s
-        @value.gsub(/\(/, '\\(').gsub(/\)/, '\\)')
+        @value.gsub(/\\/, "\\\\\\\\").gsub(/\(/, "\\(").gsub(/\)/, "\\)")
       end
     end
 

--- a/tag-expressions/ruby/lib/cucumber/tag_expressions/parser.rb
+++ b/tag-expressions/ruby/lib/cucumber/tag_expressions/parser.rb
@@ -53,7 +53,36 @@ module Cucumber
       end
 
       def tokens(infix_expression)
-        infix_expression.gsub(/(?<!\\)\(/, ' ( ').gsub(/(?<!\\)\)/, ' ) ').strip.split(/\s+/)
+        escaped = false
+        token = ""
+        result = []
+        infix_expression.chars.each do | ch |
+          if ch == '\\' && !escaped
+            escaped = true
+          else
+            if ch.match(/\s/)
+              if token.length > 0
+                result.push(token)
+                token = ""
+              end
+            else
+              if (ch == '(' || ch == ')') && !escaped
+                if token.length > 0
+                  result.push(token)
+                  token = ""
+                end
+                result.push(ch)
+              else
+                token = token + ch
+              end
+            end
+            escaped = false
+          end
+        end
+        if token.length > 0
+          result.push(token)
+        end
+        result
       end
 
       def process_tokens!(infix_expression)

--- a/tag-expressions/ruby/spec/expressions_spec.rb
+++ b/tag-expressions/ruby/spec/expressions_spec.rb
@@ -52,4 +52,33 @@ describe 'Expression node' do
       include_examples 'expression node', infix_expression, data
     end
   end
+
+  describe Cucumber::TagExpressions::Or do
+    context '#evaluate' do
+      infix_expression = 'x\\\\ or (y\\\\\\)) or (z\\\\)'
+      data = [[%w(), false],
+              [%w(x), false],
+              [%w(y\)), false],
+              [%w(z), false],
+              [%w(x\\), true],
+              [%w(y\\\)), true],
+              [%w(z\\), true]]
+      include_examples 'expression node', infix_expression, data
+    end
+  end
+
+  describe Cucumber::TagExpressions::Or do
+    context '#evaluate' do
+      infix_expression = '\\x or y\\ or z\\'
+      data = [[%w(), false],
+              [%w(\\x), false],
+              [%w(y\\), false],
+              [%w(z\\), false],
+              [%w(x), true],
+              [%w(y), true],
+              [%w(z), true]]
+      include_examples 'expression node', infix_expression, data
+    end
+  end
+
 end

--- a/tag-expressions/ruby/spec/parser_spec.rb
+++ b/tag-expressions/ruby/spec/parser_spec.rb
@@ -9,7 +9,11 @@ describe Cucumber::TagExpressions::Parser do
     ['not a or b and not c or not d or e and f',
      '( ( ( not ( a ) or ( b and not ( c ) ) ) or not ( d ) ) or ( e and f ) )'],
     ['not a\\(\\) or b and not c or not d or e and f',
-     '( ( ( not ( a\\(\\) ) or ( b and not ( c ) ) ) or not ( d ) ) or ( e and f ) )']
+     '( ( ( not ( a\\(\\) ) or ( b and not ( c ) ) ) or not ( d ) ) or ( e and f ) )'],
+     ['a\\\\ and b', '( a\\\\ and b )'],
+     ['\\a and b\\ and c\\', '( ( a and b ) and c )'],
+     ['(a and b\\\\)', '( a and b\\\\ )'],
+     ['a\\\\\\( and b\\\\\\)', '( a\\\\\\( and b\\\\\\) )']
   ]
 
   error_test_data = [


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary
<!--- Provide a general summary description of your changes -->
Add support "\\\\" escape for backslash in tag expressions.

## Details
Javascript, Java, and Go implementations of Tag Expressions cannnot handle tags containing backslashes, but Tag Expressions should be able to handle tags containing backslashes.

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #1776 
Fixes #1777

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Added the following test cases:
- "\\" before "\\". `a\\ and b`
- "\\" before normal character. `\a and b`
- "\\" before space. `a\ and b`
- "\\" is the last character of tag expressions. `a and b\`
- "\\\\" before unescaped parentheses. `( a and b\\)`
- "\\\\" before escaped parentheses. `a\\\( and b\\\)`
- normal characters between "\\" and parentheses. `(a and \b)`

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The change has been ported to Java.
- [x] The change has been ported to Ruby.
- [x] The change has been ported to JavaScript.
- [x] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG accordingly.

