### PR TITLE
gherkin-python: FIX CI build problems for PR #1779

### DIFF
--- a/gherkin/python/.gitignore
+++ b/gherkin/python/.gitignore
@@ -5,3 +5,4 @@ acceptance/
 *.pyc
 dist/
 build/
+.tox/

--- a/gherkin/python/Makefile
+++ b/gherkin/python/Makefile
@@ -9,6 +9,8 @@ SOURCES  = $(patsubst testdata/%.feature,acceptance/testdata/%.feature.source.nd
 ERRORS   = $(patsubst testdata/%.feature,acceptance/testdata/%.feature.errors.ndjson,$(BAD_FEATURE_FILES))
 
 PYTHON_FILES = $(shell find . -name "*.py")
+PYTHONPATH ?= $(PWD)
+export PYTHONPATH
 
 .DELETE_ON_ERROR:
 
@@ -19,14 +21,15 @@ default: .built .compared
 	touch $@
 
 .built: gherkin/parser.py gherkin/gherkin-languages.json $(PYTHON_FILES) bin/gherkin .pipped
-	# nosetest most likely installed in $(HOME)/.local/bin since normal
-	# site-packages most likely is not writeable
 	$(MAKE) test
 	touch $@
 
 .PHONY: test
 test: gherkin/parser.py
-	PATH=$(PATH):$(HOME)/.local/bin nosetests
+	# "pytest" is most likely installed in $(HOME)/.local/bin since normal
+	# site-packages most likely is not writeable
+	@echo "$(@): USE PYTHONPATH=$(PYTHONPATH)"
+	PATH=$(PATH):$(HOME)/.local/bin pytest
 
 .pipped:
 	pip install -r requirements.txt

--- a/gherkin/python/Makefile
+++ b/gherkin/python/Makefile
@@ -21,8 +21,12 @@ default: .built .compared
 .built: gherkin/parser.py gherkin/gherkin-languages.json $(PYTHON_FILES) bin/gherkin .pipped
 	# nosetest most likely installed in $(HOME)/.local/bin since normal
 	# site-packages most likely is not writeable
-	PATH=$(PATH):$(HOME)/.local/bin nosetests
+	$(MAKE) test
 	touch $@
+
+.PHONY: test
+test: gherkin/parser.py
+	PATH=$(PATH):$(HOME)/.local/bin nosetests
 
 .pipped:
 	pip install -r requirements.txt

--- a/gherkin/python/requirements.txt
+++ b/gherkin/python/requirements.txt
@@ -1,1 +1,7 @@
+# -- FOR TESTING:
 nose
+pytest <  5.0; python_version <  '3.0'
+pytest >= 5.0; python_version >= '3.0'
+
+# -- FOR DEVELOPMENT:
+# tox

--- a/gherkin/python/tox.ini
+++ b/gherkin/python/tox.ini
@@ -1,0 +1,25 @@
+# ============================================================================
+# TOX CONFIGURATION: gherkin-python
+# ============================================================================
+# REQUIRES: pip install tox
+# DESCRIPTION:
+#   Use tox to run tasks (tests, ...) in a clean virtual environment.
+#   For example, use an installed Python 3.9 or Python 2.7, like:
+#
+#       tox -e py39
+#       tox -e py27
+#
+# SEE ALSO:
+#   * https://tox.wiki/en/latest/config.html
+# ============================================================================
+
+[tox]
+envlist = py310, py39, py27
+
+# -----------------------------------------------------------------------------
+# TEST ENVIRONMENTS:
+# -----------------------------------------------------------------------------
+[testenv]
+commands=
+    pytest
+deps= -r {toxinidir}/requirements.txt


### PR DESCRIPTION
## Summary

FIX CI build problems for PR #1779 (step 1):

* Use "pytest" instead of "nose" as test runner
  HINT: "nose" causes problems in Python 3.10 (CI build failures)

HINT: Additional changes for step 2 are described in PR #1779 (analysis).

## Details

* Add "tox.ini" to simplify tests w/ different Python versions in the future.
* Makefile: Replace "nose" with "pytest" as test runner for unit tests.
* Makefile: Added explicit "test" target to run unit tests (instead of implicit).

## How Has This Been Tested?

Using `tox` to run unit tests in different Python version environments:

```
$ pip install tox
$ tox -e py27
$ tox -e py39
$ tox -e py310
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [x] The change has been ported to Python.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG accordingly.
