### PR TITLE
gherkin-python: Remove nose usage with pytest as  test-framework (step 2)

### DIFF
--- a/gherkin/python/.coveragerc
+++ b/gherkin/python/.coveragerc
@@ -1,0 +1,40 @@
+# =========================================================================
+# COVERAGE CONFIGURATION FILE: .coveragerc
+# =========================================================================
+# LANGUAGE: Python
+# SEE ALSO:
+#  * http://nedbatchelder.com/code/coverage/
+#  * http://nedbatchelder.com/code/coverage/config.html
+# =========================================================================
+
+[run]
+source = gherkin
+branch  = True
+parallel = True
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if False:
+    if __name__ == .__main__.:
+
+ignore_errors = True
+
+[html]
+directory = build/coverage.html
+
+[xml]
+output = build/coverage.xml

--- a/gherkin/python/.gitignore
+++ b/gherkin/python/.gitignore
@@ -6,3 +6,5 @@ acceptance/
 dist/
 build/
 .tox/
+.coverage
+.coverage.*

--- a/gherkin/python/CONTRIBUTING.md
+++ b/gherkin/python/CONTRIBUTING.md
@@ -19,9 +19,9 @@ The exception is [parser.py](https://github.com/cucumber/gherkin/blob/master/pyt
 
 Just run `make` from this directory.
 
-### Using nosetests
+### Using pytest
 
-Just run `nosetests` from this directory (you need to `pip install -r requirements.txt` first).
+Just run `pytest` from this directory (you need to `pip install -r requirements.txt` first).
 
 Keep in mind that this will only run unit tests. The acceptance tests are only
 run when you build with `make`.

--- a/gherkin/python/pytest.ini
+++ b/gherkin/python/pytest.ini
@@ -1,0 +1,20 @@
+# ============================================================================
+# PYTEST CONFIGURATION FILE
+# ============================================================================
+# NOTE: Can also be defined in in tox.ini or pytest.ini file.
+#
+# SEE ALSO:
+#  * http://pytest.org/
+#  * http://pytest.org/latest/customize.html
+#  * http://pytest.org/latest/usage.html
+# ============================================================================
+
+[pytest]
+minversion    = 4.2
+testpaths     = test
+junit_family = xunit2
+# -- DISABLED -- PREPARED FOR: HTML, XML reports (requires: pytest-html)
+# addopts = --metadata PACKAGE_UNDER_TEST gherkin-python
+#    --metadata PACKAGE_VERSION 22.0.0
+#    --html=build/testing/report.html --self-contained-html
+#    --junit-xml=build/testing/report.xml

--- a/gherkin/python/requirements.txt
+++ b/gherkin/python/requirements.txt
@@ -1,7 +1,9 @@
 # -- FOR TESTING:
-nose
 pytest <  5.0; python_version <  '3.0'
 pytest >= 5.0; python_version >= '3.0'
+# MAYBE: For pytest HTML reports.
+# pytest-html
 
 # -- FOR DEVELOPMENT:
 # tox
+# coverage >= 4.2

--- a/gherkin/python/test/count_symbols_test.py
+++ b/gherkin/python/test/count_symbols_test.py
@@ -1,16 +1,18 @@
 # coding=utf-8
 
-from nose.tools import assert_equals
 from gherkin.count_symbols import count_symbols
+
 
 def test_count_length_of_astral_point_symbols_correctly():
     string = u'\U0001f63b'
-    assert_equals(1, count_symbols(string))
+    assert 1 == count_symbols(string)
+
 
 def test_count_length_of_ascii_symbols_correctly():
     string = u'hello'
-    assert_equals(5, count_symbols(string))
+    assert 5 == count_symbols(string)
+
 
 def test_count_length_of_latin_symbols_correctly():
     string = u'Scénario'
-    assert_equals(8, count_symbols(string))
+    assert 8, count_symbols(string)

--- a/gherkin/python/test/gherkin_test.py
+++ b/gherkin/python/test/gherkin_test.py
@@ -3,7 +3,7 @@ from gherkin.token_scanner import TokenScanner
 from gherkin.token_matcher import TokenMatcher
 from gherkin.parser import Parser
 from gherkin.errors import ParserError
-from nose.tools import assert_equals, assert_raises
+import pytest
 
 
 def test_parser():
@@ -22,7 +22,7 @@ def test_parser():
         },
     }
 
-    assert_equals(expected, feature_file)
+    assert expected == feature_file
 
 
 def test_parse_multiple_features():
@@ -30,13 +30,13 @@ def test_parse_multiple_features():
     ff1 = parser.parse(TokenScanner("Feature: 1"))
     ff2 = parser.parse(TokenScanner("Feature: 2"))
 
-    assert_equals("1", ff1['feature']['name'])
-    assert_equals("2", ff2['feature']['name'])
+    assert "1" == ff1['feature']['name']
+    assert "2" == ff2['feature']['name']
 
 
 def test_parse_feature_after_parser_error():
     parser = Parser()
-    with assert_raises(ParserError):
+    with pytest.raises(ParserError):
         parser.parse(TokenScanner('# a comment\n' +
                                   'Feature: Foo\n' +
                                   '  Scenario: Bar\n' +
@@ -67,7 +67,7 @@ def test_parse_feature_after_parser_error():
         'location': {'column': 3, 'line': 2},
         'examples': []}}]
 
-    assert_equals(expected, feature_file['feature']['children'])
+    assert expected == feature_file['feature']['children']
 
 
 def test_change_the_default_language():
@@ -87,4 +87,4 @@ def test_change_the_default_language():
         },
     }
 
-    assert_equals(expected, feature_file)
+    assert expected == feature_file

--- a/gherkin/python/test/pickles_test/compiler_test.py
+++ b/gherkin/python/test/pickles_test/compiler_test.py
@@ -10,8 +10,6 @@ from gherkin.errors import ParserError
 from gherkin.pickles.compiler import Compiler
 from gherkin.stream.id_generator import IdGenerator
 
-from nose.tools import assert_equals, assert_raises
-
 
 def test_compiles_a_scenario():
     feature_text = textwrap.dedent(
@@ -46,10 +44,7 @@ def test_compiles_a_scenario():
         """
     )
 
-    assert_equals(
-        pickle,
-        json.loads(expected_pickle)
-    )
+    assert pickle == json.loads(expected_pickle)
 
 
 def test_compiles_a_scenario_outline_with_i18n_characters():
@@ -88,7 +83,4 @@ def test_compiles_a_scenario_outline_with_i18n_characters():
         """
     )
 
-    assert_equals(
-        pickle,
-        json.loads(expected_pickle)
-    )
+    assert pickle == json.loads(expected_pickle)

--- a/gherkin/python/tox.ini
+++ b/gherkin/python/tox.ini
@@ -21,5 +21,20 @@ envlist = py310, py39, py27
 # -----------------------------------------------------------------------------
 [testenv]
 commands=
-    pytest
+    pytest {posargs}
 deps= -r {toxinidir}/requirements.txt
+setenv =
+     PYTHONPATH = {toxinidir}
+
+# -- USE: tox -e coverage
+[testenv:coverage]
+commands=
+    coverage run -m pytest {posargs}
+    coverage combine
+    coverage report
+    coverage html
+deps=
+    coverage >= 4.2
+    {[testenv]deps}
+setenv =
+     PYTHONPATH = {toxinidir}


### PR DESCRIPTION
## Summary

Replace "nose" with "pytest" as test framework (step 2) fro unit tests.
"nose" is no longer maintained.

DEPENDS ON:
* PR #1819: Use "pytest" as test runner instead of "nose" (aka: step 1)
    
RELATED TO:
* PR #1779: "nose" caused problem in CI builds since Python 3.10.

## Details

* Replace nose.tools (assert helpers) with pytest equivalent in tests.
* Remove "nose" usage (in: test/*.py, "requirements.txt")
    
In addition:
    
* Simplify test coverage by using "tox.ini"
* PREPARED: Use of HTML test reports (with: pytest-html)

## Motivation and Context

Using `nose` cause problems in the CI build with Python 3.10.
This PR provides the second step that finally allows to remove `nose` completely.
`pytest` is used instead (as test runner, assert-helper where needed).

## How Has This Been Tested?

* Running the test suite with "make" and "tox" for different Python versions (2.7, 3.9, 3.10)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] Maintenance/development cleanup to avoid the problems mentioned above in the future.
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [x] The change has been ported to Python.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly (in: CONTRIBUTING.md).
- [ ] I have updated the CHANGELOG accordingly.

