### PR TITLE
Remove subrepo sync for html-formatter/javascript

### DIFF
--- a/html-formatter/javascript/.subrepo
+++ b/html-formatter/javascript/.subrepo
@@ -1,1 +1,0 @@
-cucumber/html-formatter


### PR DESCRIPTION
In order to start moving out html-formatter from the monorepo, the synchronization of its javascript subrepo is removed. That way we can use the already-existing https://github.com/cucumber/html-formatter repository