### PR TITLE
Add default in the php pre-release default makefiles

### DIFF
--- a/.templates/php/default.mk
+++ b/.templates/php/default.mk
@@ -21,7 +21,7 @@ endef
 default: .tested
 .PHONY: default
 
-pre-release: update-version update-dependencies
+pre-release: update-version update-dependencies default
 .PHONY: pre-release
 
 update-version:

--- a/gherkin/php/default.mk
+++ b/gherkin/php/default.mk
@@ -21,7 +21,7 @@ endef
 default: .tested
 .PHONY: default
 
-pre-release: update-version update-dependencies
+pre-release: update-version update-dependencies default
 .PHONY: pre-release
 
 update-version:

--- a/messages/php/default.mk
+++ b/messages/php/default.mk
@@ -21,7 +21,7 @@ endef
 default: .tested
 .PHONY: default
 
-pre-release: update-version update-dependencies
+pre-release: update-version update-dependencies default
 .PHONY: pre-release
 
 update-version:


### PR DESCRIPTION
The `default` target was missing in the `pre-release` target for php projects.
That led into messages not being regenerated when trying to pre-release 18.0.0, and tests not being executed after the dependencies have been upgraded.

