### PR TITLE
Fix PHP Gherkin->Messages dependency

### DIFF
--- a/gherkin/php/Makefile
+++ b/gherkin/php/Makefile
@@ -16,14 +16,6 @@ default: .compared
 .compared: .deps $(TOKENS) $(SOURCES) $(ASTS) $(PICKLES) $(ERRORS)
 	touch $@
 
-pre-release: remove-messages-dev-dependency
-
-remove-messages-dev-dependency:
-	# dependency on messages is like 'dev-main||^12.0,^13.0,...etc
-	jq '.require["cucumber/messages"] |= sub("dev-main(\\|\\|)?";"")' --indent 4 < composer.json > composer.json.new
-	mv composer.json.new composer.json
-.PHONY: remove-messages-dev-dependency
-
 acceptance/testdata/%.feature.tokens: testdata/%.feature testdata/%.feature.tokens
 	mkdir -p $(@D)
 	bin/gherkin-generate-tokens $< > $@

--- a/gherkin/php/composer.json
+++ b/gherkin/php/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "^8.1",
         "ext-mbstring": "*",
-        "cucumber/messages": "^17.0,^18.0"
+        "cucumber/messages": "^18.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
@@ -26,7 +26,12 @@
     "repositories": [
         {
             "type": "path",
-            "url": "../../messages/php"
+            "url": "../../messages/php",
+            "options": {
+                "versions": {
+                    "cucumber/messages": "18.0.0"
+                }
+            }
         }
     ]
 }

--- a/messages/php/scripts/update-gherkin-dependency.php
+++ b/messages/php/scripts/update-gherkin-dependency.php
@@ -38,14 +38,15 @@ if (!preg_match('/^(?<major>\\d+)\\.\\d+\\.\\d+$/', $newVersion, $matches)) {
 }
 
 // like ^21.0 (same as >=21.0.0 <22.0.0)
-$newDependency = ',^'.$matches['major'].'.0';
+$newDependency = '^'.$matches['major'].'.0';
 
 if (str_contains($dependencyString, $newDependency)) {
     fwrite(STDERR, 'Nothing to update, already depends on ' . $newDependency . "\n");
     $newDependency = '';
 }
 
-$newDependencyString = $dependencyString . $newDependency;
+// '||' is OR
+$newDependencyString = $dependencyString . '||' .$newDependency;
 
 $json['require']['cucumber/messages'] = $newDependencyString;
 


### PR DESCRIPTION
When messages 18.0.0 was released, the constraint in gherkin/php/composer.json was changed to `dev-main||^17.0,^18.0`. This is incorrect because `,` is AND. It should have been `dev-main||^17.0||^18.0`

Pre-release of gherkin 23.0.0 removed the `dev-main` and left it as `^17.0,^18.0`. Despite visual inspection by me this was approved and released. It is currently uninstallable as a result.

This removes the script that got rid of 'dev-main', fixes the constraint by removing `^17.0` as there is no php tag for that, and updates the messages script that adds new versions. Fixing this will require a `23.0.1` tag :/

The other issue was builds on main failing. This is because the local 'path repository' that makes gherkin install messages from local filesystem is unable to tell what version the checkout is. It's now forced to be 18.0.0 and only needs updating when gherkin breaks backward support for messages
