### PR TITLE
CCK: Add implementation of named hook in ruby

### DIFF
--- a/compatibility-kit/CHANGELOG.md
+++ b/compatibility-kit/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* [Ruby] Add implementation for named hooks
+
 ## [9.2.0] - 2022-04-01
 
 ### Added

--- a/compatibility-kit/CHANGELOG.md
+++ b/compatibility-kit/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-* [Ruby] Add implementation for named hooks
+* [Ruby] Add implementation for named hooks ([#1984](https://github.com/cucumber/common/pull/1984))
 
 ## [9.2.0] - 2022-04-01
 

--- a/compatibility-kit/javascript/features/hooks/hooks.feature
+++ b/compatibility-kit/javascript/features/hooks/hooks.feature
@@ -1,3 +1,4 @@
+@exclude-json-formatter
 Feature: Hooks
   Hooks are special steps that run before or after each scenario's steps.
   They can also conditionally target specific scenarios, using tag expressions

--- a/compatibility-kit/javascript/features/hooks/hooks.feature
+++ b/compatibility-kit/javascript/features/hooks/hooks.feature
@@ -1,4 +1,3 @@
-@exclude-json-formatter
 Feature: Hooks
   Hooks are special steps that run before or after each scenario's steps.
   They can also conditionally target specific scenarios, using tag expressions

--- a/compatibility-kit/ruby/features/hooks/hooks.feature.rb
+++ b/compatibility-kit/ruby/features/hooks/hooks.feature.rb
@@ -7,8 +7,7 @@ Before do
   # no-op
 end
 
-Before do
-  # This is the equivalent of the new named hook in typescript
+Before(name: 'A named hook') do
   # no-op
 end
 

--- a/json-formatter/ruby-testdata/Gemfile
+++ b/json-formatter/ruby-testdata/Gemfile
@@ -4,6 +4,6 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem "cucumber", "~> 7.1.0"
+gem "cucumber", git: 'https://github.com/cucumber/cucumber-ruby.git', branch: 'add-support-for-named-hooks'
 gem "json"
 gem "rspec"


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

About to release cucumber-ruby 8.0.0.
After upgrading all the gems, cucumber-ruby does not pass the CCK due to missing named hooks support.
It is actually pretty easy to add, so, let's add it in the CCK first, then on cucumber-ruby.

Here, we just need to add a name to the "Before" hook in the ruby step definitions
