### PR TITLE
[Perl] Align Makefile and default.mk more with Ruby

### DIFF
--- a/.templates/perl/default.mk
+++ b/.templates/perl/default.mk
@@ -3,7 +3,11 @@
 #     source scripts/functions.sh && rsync_files
 #
 SHELL := /usr/bin/env bash
-ALPINE := $(shell which apk 2> /dev/null)
+PERL_SOURCE_FILES = $(shell find lib -name '*.pm') $(shell test -d bin && find bin -type f) $(shell find t -name '*.t')
+LIBNAME := $(shell head -10 dist.ini | grep 'name.*=' | sed -e 's/name.*= *//')
+DISTINI  = $(shell find . -name 'dist.ini')
+DIST := $(LIBNAME)-$(NEW_VERSION).tar.gz
+IS_TESTDATA = $(findstring -testdata,${CURDIR})
 
 ### COMMON stuff for all platforms
 
@@ -18,20 +22,42 @@ endef
 
 ### Common targets for all functionalities implemented on Perl
 
-default: test
+default: .tested
 .PHONY: default
 
-CHANGELOG.md: ../CHANGELOG.md
-	cp ../CHANGELOG.md CHANGELOG.md
+.deps: .cpanfile_dependencies
+	touch $@
 
-distribution: predistribution
-	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil test --release
+.cpanfile_dependencies: cpanfile dist.ini
+	# --notest to keep the number of dependencies low: it doesn't install the
+	# testing dependencies of the dependencies.
+	cpanm --notest --local-lib ./perl5 --installdeps --with-develop .
+	cpanm --notest --local-lib ./perl5 'Dist::Zilla'
+	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil authordeps --missing | cpanm --notest --local-lib ./perl5
+	touch $@
+
+.tested: .deps $(PERL_SOURCE_FILES)
+	PERL5LIB=${PERL5LIB} prove -l
+	touch $@
+
+ifdef NEW_VERSION
+ifneq (,$(DISTINI))
+dist: $(DIST)
+else
+dist:
+	@echo "Not building dist because there is no dist.ini"
+endif
+endif
+.PHONY: dist
+
+$(DIST): .tested
+	@(git status --porcelain 2>/dev/null | grep "^??" | perl -ne\
+	    'die "The `release` target includes all files in the working directory. Please remove [$$_], or add it to .gitignore if it should be included\n" if s!.+ perl/(.+?)\n!$$1!')
 	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil build
-.PHONY: distribution
+	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} cpanm --local-lib $(shell mktemp -d) --test-only $(DIST)
 
-publish: predistribution
-	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil release
-.PHONY: publish
+pre-release: update-version CHANGELOG.md dist
+.PHONY: pre-release
 
 update-version:
 ifdef NEW_VERSION
@@ -42,28 +68,31 @@ else
 endif
 .PHONY: update-version
 
-.cpanfile_dependencies: cpanfile
-	PERL5LIB=${PERL5LIB} cpanm --notest --local-lib ./perl5 --installdeps .
-	touch $@
 
-predistribution: dist-clean test CHANGELOG.md
-# --notest to keep the number of dependencies low: it doesn't install the
-# testing dependencies of the dependencies.
-	cpanm --notest --local-lib ./perl5 --installdeps --with-develop .
-	cpanm --notest --local-lib ./perl5 'Dist::Zilla'
-	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil authordeps --missing | cpanm --notest --local-lib ./perl5
-	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil clean
-	@(git status --porcelain 2>/dev/null | grep "^??" | perl -ne\
-	    'die "The `release` target includes all files in the working directory. Please remove [$$_], or add it to .gitignore if it should be included\n" if s!.+ perl/(.+?)\n!$$1!')
-.PHONY: predistribution
-
-pre-release: update-version
-.PHONY: pre-release
+publish: dist
+ifeq ($(IS_TESTDATA),-testdata)
+	# no-op
+else
+ifneq (,$(DISTINI))
+	cpan-upload $(DIST)
+endif
+endif
+.PHONY: publish
 
 post-release:
 .PHONY: post-release
 
-dist-clean: clean
-	rm -rf ./perl5
+perl-clean:
+	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil clean
+	rm -rf ./perl5 .deps .cpanfile_dependencies .tested
+.PHONY: perl-clean
 
+clean: perl-clean
+.PHONY: clean
+
+CHANGELOG.md: ../CHANGELOG.md
+	cp ../CHANGELOG.md CHANGELOG.md
+
+
+dist-clean: clean
 .PHONY: dist-clean

--- a/gherkin/perl/Makefile
+++ b/gherkin/perl/Makefile
@@ -17,51 +17,39 @@ ERRORS   = $(patsubst ../testdata/%.feature,acceptance/testdata/%.feature.errors
 
 .DELETE_ON_ERROR:
 
-test: .built $(TOKENS) $(ASTS) $(PICKLES)
-	PERL5LIB=${PERL5LIB} prove -l
+default: .compared
 
-.built: .cpanfile_dependencies lib/Gherkin/Generated/Parser.pm lib/Gherkin/Generated/Languages.pm bin/gherkin-generate-tokens LICENSE.txt
-	@$(MAKE) --no-print-directory show-version-info
-	# add Perl-level unit tests
+.deps: lib/Gherkin/Generated/Parser.pm lib/Gherkin/Generated/Languages.pm
+
+.compared: $(TOKENS) $(ASTS) $(PICKLES) # $(ERRORS)
 	touch $@
 
-show-version-info:
-	perl --version
-.PHONY: show-version-info
-
-acceptance/testdata/%.feature.tokens: ../testdata/%.feature ../testdata/%.feature.tokens .built
+acceptance/testdata/%.feature.tokens: ../testdata/%.feature ../testdata/%.feature.tokens .deps
 	mkdir -p $(@D)
 	PERL5LIB=${PERL5LIB} bin/gherkin-generate-tokens $< > $@
 	diff --unified $<.tokens $@
 
-acceptance/testdata/%.feature.ast.ndjson: ../testdata/%.feature ../testdata/%.feature.ast.ndjson .built
+acceptance/testdata/%.feature.ast.ndjson: ../testdata/%.feature ../testdata/%.feature.ast.ndjson .deps
 	mkdir -p $(@D)
 	PERL5LIB=${PERL5LIB} bin/gherkin --predictable-ids --no-source --no-pickles $< > $@
 	diff --unified <(jq "." $<.ast.ndjson) <(jq "." $@)
 
-acceptance/testdata/%.feature.pickles.ndjson: ../testdata/%.feature ../testdata/%.feature.pickles.ndjson .built
+acceptance/testdata/%.feature.pickles.ndjson: ../testdata/%.feature ../testdata/%.feature.pickles.ndjson .deps
 	mkdir -p $(@D)
 	PERL5LIB=${PERL5LIB} bin/gherkin --predictable-ids --no-source --no-ast $< > $@
 	diff --unified <(jq "." $<.pickles.ndjson) <(jq "." $@)
 
-acceptance/testdata/%.feature.errors.ndjson: ../testdata/%.feature ../testdata/%.feature.errors.ndjson .built
-	mkdir -p $(@D)
-	PERL5LIB=${PERL5LIB} bin/gherkin --predictable-ids --no-source --no-pickles $< > $@
-	diff --unified <(jq "." $<.errors.ndjson) <(jq "." $@)
-
-post-release:
-.PHONY: post-release
-
-update-dependencies:
-	@echo -e "\033[0;31mPlease update dependencies for perl manually!!\033[0m"
-.PHONY: update-dependencies
+#acceptance/testdata/%.feature.errors.ndjson: ../testdata/%.feature ../testdata/%.feature.errors.ndjson .deps
+#	mkdir -p $(@D)
+#	PERL5LIB=${PERL5LIB} bin/gherkin --predictable-ids --no-pickles $< | jq --sort-keys --compact-output "." > $@
+#	diff --unified <(jq "." $<.errors.ndjson) <(jq "." $@)
 
 clean:
-	rm -rf Gherkin-* .cpanfile_dependencies .built acceptance CHANGELOG.md
+	rm -rf .compared acceptance
 .PHONY: clean
 
 clobber: clean
-	rm -rf lib/Gherkin/Generated/Languages.pm lib/Gherkin/Generated/Parser.pm
+	rm -rf lib/Gherkin/Generated
 .PHONY: clobber
 
 lib/Gherkin/Generated:
@@ -72,6 +60,3 @@ lib/Gherkin/Generated/Languages.pm: gherkin-languages.json .cpanfile_dependencie
 
 lib/Gherkin/Generated/Parser.pm: gherkin-perl.razor gherkin.berp
 	$(berp-generate-parser)
-
-pre-release: update-version
-.PHONY: pre-release

--- a/gherkin/perl/default.mk
+++ b/gherkin/perl/default.mk
@@ -3,7 +3,11 @@
 #     source scripts/functions.sh && rsync_files
 #
 SHELL := /usr/bin/env bash
-ALPINE := $(shell which apk 2> /dev/null)
+PERL_SOURCE_FILES = $(shell find lib -name '*.pm') $(shell test -d bin && find bin -type f) $(shell find t -name '*.t')
+LIBNAME := $(shell head -10 dist.ini | grep 'name.*=' | sed -e 's/name.*= *//')
+DISTINI  = $(shell find . -name 'dist.ini')
+DIST := $(LIBNAME)-$(NEW_VERSION).tar.gz
+IS_TESTDATA = $(findstring -testdata,${CURDIR})
 
 ### COMMON stuff for all platforms
 
@@ -18,20 +22,42 @@ endef
 
 ### Common targets for all functionalities implemented on Perl
 
-default: test
+default: .tested
 .PHONY: default
 
-CHANGELOG.md: ../CHANGELOG.md
-	cp ../CHANGELOG.md CHANGELOG.md
+.deps: .cpanfile_dependencies
+	touch $@
 
-distribution: predistribution
-	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil test --release
+.cpanfile_dependencies: cpanfile dist.ini
+	# --notest to keep the number of dependencies low: it doesn't install the
+	# testing dependencies of the dependencies.
+	cpanm --notest --local-lib ./perl5 --installdeps --with-develop .
+	cpanm --notest --local-lib ./perl5 'Dist::Zilla'
+	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil authordeps --missing | cpanm --notest --local-lib ./perl5
+	touch $@
+
+.tested: .deps $(PERL_SOURCE_FILES)
+	PERL5LIB=${PERL5LIB} prove -l
+	touch $@
+
+ifdef NEW_VERSION
+ifneq (,$(DISTINI))
+dist: $(DIST)
+else
+dist:
+	@echo "Not building dist because there is no dist.ini"
+endif
+endif
+.PHONY: dist
+
+$(DIST): .tested
+	@(git status --porcelain 2>/dev/null | grep "^??" | perl -ne\
+	    'die "The `release` target includes all files in the working directory. Please remove [$$_], or add it to .gitignore if it should be included\n" if s!.+ perl/(.+?)\n!$$1!')
 	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil build
-.PHONY: distribution
+	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} cpanm --local-lib $(shell mktemp -d) --test-only $(DIST)
 
-publish: predistribution
-	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil release
-.PHONY: publish
+pre-release: update-version CHANGELOG.md dist
+.PHONY: pre-release
 
 update-version:
 ifdef NEW_VERSION
@@ -42,28 +68,31 @@ else
 endif
 .PHONY: update-version
 
-.cpanfile_dependencies: cpanfile
-	PERL5LIB=${PERL5LIB} cpanm --notest --local-lib ./perl5 --installdeps .
-	touch $@
 
-predistribution: dist-clean test CHANGELOG.md
-# --notest to keep the number of dependencies low: it doesn't install the
-# testing dependencies of the dependencies.
-	cpanm --notest --local-lib ./perl5 --installdeps --with-develop .
-	cpanm --notest --local-lib ./perl5 'Dist::Zilla'
-	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil authordeps --missing | cpanm --notest --local-lib ./perl5
-	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil clean
-	@(git status --porcelain 2>/dev/null | grep "^??" | perl -ne\
-	    'die "The `release` target includes all files in the working directory. Please remove [$$_], or add it to .gitignore if it should be included\n" if s!.+ perl/(.+?)\n!$$1!')
-.PHONY: predistribution
-
-pre-release: update-version
-.PHONY: pre-release
+publish: dist
+ifeq ($(IS_TESTDATA),-testdata)
+	# no-op
+else
+ifneq (,$(DISTINI))
+	cpan-upload $(DIST)
+endif
+endif
+.PHONY: publish
 
 post-release:
 .PHONY: post-release
 
-dist-clean: clean
-	rm -rf ./perl5
+perl-clean:
+	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil clean
+	rm -rf ./perl5 .deps .cpanfile_dependencies .tested
+.PHONY: perl-clean
 
+clean: perl-clean
+.PHONY: clean
+
+CHANGELOG.md: ../CHANGELOG.md
+	cp ../CHANGELOG.md CHANGELOG.md
+
+
+dist-clean: clean
 .PHONY: dist-clean

--- a/messages/perl/default.mk
+++ b/messages/perl/default.mk
@@ -3,7 +3,11 @@
 #     source scripts/functions.sh && rsync_files
 #
 SHELL := /usr/bin/env bash
-ALPINE := $(shell which apk 2> /dev/null)
+PERL_SOURCE_FILES = $(shell find lib -name '*.pm') $(shell test -d bin && find bin -type f) $(shell find t -name '*.t')
+LIBNAME := $(shell head -10 dist.ini | grep 'name.*=' | sed -e 's/name.*= *//')
+DISTINI  = $(shell find . -name 'dist.ini')
+DIST := $(LIBNAME)-$(NEW_VERSION).tar.gz
+IS_TESTDATA = $(findstring -testdata,${CURDIR})
 
 ### COMMON stuff for all platforms
 
@@ -18,20 +22,42 @@ endef
 
 ### Common targets for all functionalities implemented on Perl
 
-default: test
+default: .tested
 .PHONY: default
 
-CHANGELOG.md: ../CHANGELOG.md
-	cp ../CHANGELOG.md CHANGELOG.md
+.deps: .cpanfile_dependencies
+	touch $@
 
-distribution: predistribution
-	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil test --release
+.cpanfile_dependencies: cpanfile dist.ini
+	# --notest to keep the number of dependencies low: it doesn't install the
+	# testing dependencies of the dependencies.
+	cpanm --notest --local-lib ./perl5 --installdeps --with-develop .
+	cpanm --notest --local-lib ./perl5 'Dist::Zilla'
+	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil authordeps --missing | cpanm --notest --local-lib ./perl5
+	touch $@
+
+.tested: .deps $(PERL_SOURCE_FILES)
+	PERL5LIB=${PERL5LIB} prove -l
+	touch $@
+
+ifdef NEW_VERSION
+ifneq (,$(DISTINI))
+dist: $(DIST)
+else
+dist:
+	@echo "Not building dist because there is no dist.ini"
+endif
+endif
+.PHONY: dist
+
+$(DIST): .tested
+	@(git status --porcelain 2>/dev/null | grep "^??" | perl -ne\
+	    'die "The `release` target includes all files in the working directory. Please remove [$$_], or add it to .gitignore if it should be included\n" if s!.+ perl/(.+?)\n!$$1!')
 	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil build
-.PHONY: distribution
+	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} cpanm --local-lib $(shell mktemp -d) --test-only $(DIST)
 
-publish: predistribution
-	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil release
-.PHONY: publish
+pre-release: update-version CHANGELOG.md dist
+.PHONY: pre-release
 
 update-version:
 ifdef NEW_VERSION
@@ -42,28 +68,31 @@ else
 endif
 .PHONY: update-version
 
-.cpanfile_dependencies: cpanfile
-	PERL5LIB=${PERL5LIB} cpanm --notest --local-lib ./perl5 --installdeps .
-	touch $@
 
-predistribution: dist-clean test CHANGELOG.md
-# --notest to keep the number of dependencies low: it doesn't install the
-# testing dependencies of the dependencies.
-	cpanm --notest --local-lib ./perl5 --installdeps --with-develop .
-	cpanm --notest --local-lib ./perl5 'Dist::Zilla'
-	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil authordeps --missing | cpanm --notest --local-lib ./perl5
-	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil clean
-	@(git status --porcelain 2>/dev/null | grep "^??" | perl -ne\
-	    'die "The `release` target includes all files in the working directory. Please remove [$$_], or add it to .gitignore if it should be included\n" if s!.+ perl/(.+?)\n!$$1!')
-.PHONY: predistribution
-
-pre-release: update-version
-.PHONY: pre-release
+publish: dist
+ifeq ($(IS_TESTDATA),-testdata)
+	# no-op
+else
+ifneq (,$(DISTINI))
+	cpan-upload $(DIST)
+endif
+endif
+.PHONY: publish
 
 post-release:
 .PHONY: post-release
 
-dist-clean: clean
-	rm -rf ./perl5
+perl-clean:
+	PERL5LIB=${PERL5LIB} PATH=$$PATH:${PERL5PATH} dzil clean
+	rm -rf ./perl5 .deps .cpanfile_dependencies .tested
+.PHONY: perl-clean
 
+clean: perl-clean
+.PHONY: clean
+
+CHANGELOG.md: ../CHANGELOG.md
+	cp ../CHANGELOG.md CHANGELOG.md
+
+
+dist-clean: clean
 .PHONY: dist-clean


### PR DESCRIPTION
By using the same build targets, where possible, and the same
division of concerns between 'pre-release', 'test', 'clean' and
'publish', the release process be more comprehensible for non-Perl
contributors.
