### PR TITLE
[Perl] Fix out-of-tree tests

### DIFF
--- a/gherkin/perl/t/020_parser_instantiation.t
+++ b/gherkin/perl/t/020_parser_instantiation.t
@@ -13,7 +13,7 @@ use Gherkin::TokenScanner;
 # Three different ways we can pass content to the parser, try each and check
 # we get the same thing back each time.
 
-my $file = file(qw/.. testdata good background.feature/);
+my $file = file(qw/t data background.feature/);
 my $content = $file->slurp;
 my %results;
 

--- a/gherkin/perl/t/data/background.feature
+++ b/gherkin/perl/t/data/background.feature
@@ -1,0 +1,11 @@
+Feature: Background
+
+  Background: a simple background
+    Given the minimalism inside a background
+
+
+  Scenario: minimalistic
+    Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism


### PR DESCRIPTION
With the testdata removed from the directory of each implementation,
the Perl testsuite was adapted to reference outside of the Perl directory
to access a test file. This strategy doesn't work when a dist has been
created and the dist is running its tests outside of the development
tree.

Instead, copy a single simple test file (which needs to be valid, but
doesn't need to be inline with the rest of the testsuite: we're not
using the results, only the success value) into the test tree.
