### PR TITLE
Gherkin PHP - fix post-release script

### DIFF
--- a/messages/php/scripts/update-gherkin-dependency.php
+++ b/messages/php/scripts/update-gherkin-dependency.php
@@ -42,7 +42,7 @@ $newDependency = '^'.$matches['major'].'.0';
 
 if (str_contains($dependencyString, $newDependency)) {
     fwrite(STDERR, 'Nothing to update, already depends on ' . $newDependency . "\n");
-    $newDependency = '';
+    exit(0);
 }
 
 // '||' is OR


### PR DESCRIPTION
This was incorrectly appending `||` to the dependency list on minor release