### PR TITLE
[Messages][Javascript] Prevent ignoring schemas from npm package

### DIFF
--- a/messages/javascript/package.json
+++ b/messages/javascript/package.json
@@ -8,7 +8,7 @@
   "files": [
     "dist/cjs",
     "dist/esm",
-    "schema"
+    "schema/*.json"
   ],
   "module": "dist/esm/src/index.js",
   "exports": {

--- a/messages/javascript/schema/.npmignore
+++ b/messages/javascript/schema/.npmignore
@@ -1,0 +1,3 @@
+.gitkeep
+.gitignore
+!*.json


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Due to how npm package.json#files works, the schemas has been ignored once again from 19.1.1

This PR attempts to add the schema to the messages package again