### PR TITLE
messages: extend javascript message type with workerId

### DIFF
--- a/messages/CHANGELOG.md
+++ b/messages/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* [Javascript] Add `workerId` to `Message` type
+  ([PR#2033](https://github.com/cucumber/common/pull/2033))
+
 ### Changed
 
 ### Deprecated

--- a/messages/javascript/src/messages.ts
+++ b/messages/javascript/src/messages.ts
@@ -80,6 +80,9 @@ export class Envelope {
 
   @Type(() => UndefinedParameterType)
   undefinedParameterType?: UndefinedParameterType
+
+  @Type(() => String)
+  workerId?: string
 }
 
 export class GherkinDocument {


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Provide optional `workerId` property to `Message` type

## Details

`workerId` property, which can be useful for some cases, when you need to capture additional testing details. The changes required only for `javascript` message type because most of another platforms don't have problem with thread ID identifying.

Then I want to provide additional PR for `cucumber-js` where I plan to use the property.

## Motivation and Context

`allure-cucumberjs` needs to have access to thread or worker id for better reports.

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [x] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.

