### PR TITLE
PHP Gherkin Parser: v24 is not compatible with v18 of messages

### DIFF
--- a/gherkin/CHANGELOG.md
+++ b/gherkin/CHANGELOG.md
@@ -19,6 +19,8 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ### Fixed
 
+* [PHP] Disallow installation of Messages `18.x` ([#2034](https://github.com/cucumber/common/pull/2034))
+
 ## [24.0.0] - 2022-05-31
 
 ### Added

--- a/gherkin/php/composer.json
+++ b/gherkin/php/composer.json
@@ -29,7 +29,7 @@
             "url": "../../messages/php",
             "options": {
                 "versions": {
-                    "cucumber/messages": "18.0.0"
+                    "cucumber/messages": "19.0.0"
                 }
             }
         }

--- a/gherkin/php/composer.json
+++ b/gherkin/php/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "^8.1",
         "ext-mbstring": "*",
-        "cucumber/messages": "^18.0||^19.0"
+        "cucumber/messages": "^19.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Updated `composer.json` to require at least v19 of cubumber PHP messages
<!--- Provide a general summary description of your changes -->

## Details

When using v24 with lowest dependencies:

```
cucumber/gherkin                      v24.0.0     Gherkin parser
cucumber/messages                     v18.0.0     JSON schema-based messages for Cucumber's inter-process communication
```

We get the following error:

```
PHP Fatal error:  Uncaught Error: Class "Cucumber\Messages\Step\KeywordType" not found in /home/daniel/www/dantleech/gherkin-lint/vendor/cucumber/gherkin/src/GherkinParser.php:38
```

With v19.0.0 of cucumber/messages it works.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
