### PR TITLE
[JavaScript] Fix the gherkin build

### DIFF
--- a/gherkin/javascript/Makefile
+++ b/gherkin/javascript/Makefile
@@ -8,7 +8,7 @@ PICKLES      = $(patsubst ../testdata/%,acceptance/testdata/%.pickles.ndjson,$(G
 SOURCES      = $(patsubst ../testdata/%,acceptance/testdata/%.source.ndjson,$(GOOD_FEATURE_FILES))
 ERRORS       = $(patsubst ../testdata/%,acceptance/testdata/%.errors.ndjson,$(BAD_FEATURE_FILES))
 
-GHERKIN = npx gherkin
+GHERKIN = npx gherkin-javascript
 
 .DELETE_ON_ERROR:
 


### PR DESCRIPTION
The Makefile tried to use `npx gherkin` to execute gherkin using
gherkin-streams. Actually the [gherkin-streams bin entrypoint is
named `gherkin-javascript`](https://github.com/cucumber/gherkin-streams/blob/main/package.json#L8).

