### PR TITLE
gherkin/java: Upgrade to JUnit 5

### DIFF
--- a/gherkin/java/pom.xml
+++ b/gherkin/java/pom.xml
@@ -34,6 +34,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.9.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -63,9 +70,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/gherkin/java/src/test/java/io/cucumber/gherkin/GherkinDialectProviderTest.java
+++ b/gherkin/java/src/test/java/io/cucumber/gherkin/GherkinDialectProviderTest.java
@@ -1,13 +1,12 @@
 package io.cucumber.gherkin;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.Set;
 
 import static io.cucumber.gherkin.StringUtils.symbolCount;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GherkinDialectProviderTest {
     @Test

--- a/gherkin/java/src/test/java/io/cucumber/gherkin/GherkinDocumentBuilderTest.java
+++ b/gherkin/java/src/test/java/io/cucumber/gherkin/GherkinDocumentBuilderTest.java
@@ -6,11 +6,11 @@ import io.cucumber.messages.types.FeatureChild;
 import io.cucumber.messages.types.GherkinDocument;
 import io.cucumber.messages.types.Pickle;
 import io.cucumber.messages.types.TableRow;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GherkinDocumentBuilderTest {
     private final IdGenerator idGenerator = new IncrementingIdGenerator();

--- a/gherkin/java/src/test/java/io/cucumber/gherkin/GherkinLineTest.java
+++ b/gherkin/java/src/test/java/io/cucumber/gherkin/GherkinLineTest.java
@@ -1,14 +1,14 @@
 package io.cucumber.gherkin;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class GherkinLineTest {
 

--- a/gherkin/java/src/test/java/io/cucumber/gherkin/GherkinParserTest.java
+++ b/gherkin/java/src/test/java/io/cucumber/gherkin/GherkinParserTest.java
@@ -8,13 +8,13 @@ import io.cucumber.messages.types.Pickle;
 import io.cucumber.messages.types.PickleStep;
 import io.cucumber.messages.types.Scenario;
 import io.cucumber.messages.types.Source;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
 import static io.cucumber.messages.types.SourceMediaType.TEXT_X_CUCUMBER_GHERKIN_PLAIN;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GherkinParserTest {
     final Envelope envelope = Envelope.of(new Source("minimal.feature",

--- a/gherkin/java/src/test/java/io/cucumber/gherkin/MessageVersionTest.java
+++ b/gherkin/java/src/test/java/io/cucumber/gherkin/MessageVersionTest.java
@@ -1,9 +1,9 @@
 package io.cucumber.gherkin;
 
 import io.cucumber.messages.types.Envelope;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 // This tests that the message library exposes its version. This test is hard to do in the
 // library itself since it requires running against a packaged version (jar).

--- a/gherkin/java/src/test/java/io/cucumber/gherkin/ParserTest.java
+++ b/gherkin/java/src/test/java/io/cucumber/gherkin/ParserTest.java
@@ -2,9 +2,9 @@ package io.cucumber.gherkin;
 
 import io.cucumber.messages.IdGenerator;
 import io.cucumber.messages.types.GherkinDocument;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ParserTest {
 


### PR DESCRIPTION
## Summary

Replaces JUnit 4 with JUnit 5